### PR TITLE
API-1581 Expose setting connector properties in ApiClient.Builder

### DIFF
--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -815,6 +815,11 @@ public class ApiClient implements AutoCloseable {
             return this;
         }
 
+        public Builder withProperty(String name, Object value) {
+            properties.setProperty(name, value);
+            return this;
+        }
+
         public ApiClient build() {
             return new ApiClient(this);
         }
@@ -844,7 +849,14 @@ public class ApiClient implements AutoCloseable {
         }
 
         public void setProperty(String key, Object value) {
-            properties.put(key, value);
+            if (key != null) {
+                if (value != null) {
+                    properties.put(key, value);
+                }
+                else {
+                    properties.remove(key);
+                }
+            }
         }
 
         public ConnectorProperties copy() {


### PR DESCRIPTION
Allows HTTP connector-specific properties to be set in `ApiClient.Builder` to allow custom configuration.  This includes the ability to override the specific HTTP connector provider to be used by `ApiClient`.