### PR TITLE
API-1581 Add status reason phrase to ApiResponse

### DIFF
--- a/resources/sdk/purecloudjava/extensions/ApiResponse.java
+++ b/resources/sdk/purecloudjava/extensions/ApiResponse.java
@@ -1,11 +1,11 @@
 package com.mypurecloud.sdk.v2;
 
-import java.util.List;
 import java.util.Map;
 
 public interface ApiResponse<T> extends AutoCloseable {
     Exception getException();
     Integer getStatusCode();
+    String getStatusReasonPhrase();
     boolean hasRawBody();
     String getRawBody();
     T getBody();

--- a/resources/sdk/purecloudjava/extensions/connector/ApiClientConnectorResponse.java
+++ b/resources/sdk/purecloudjava/extensions/connector/ApiClientConnectorResponse.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public interface ApiClientConnectorResponse extends AutoCloseable {
     int getStatusCode();
+    String getStatusReasonPhrase();
     Map<String, String> getHeaders();
     boolean hasBody();
     String readBody() throws IOException;

--- a/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpResponse.java
+++ b/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpResponse.java
@@ -38,6 +38,11 @@ class ApacheHttpResponse implements ApiClientConnectorResponse {
     }
 
     @Override
+    public String getStatusReasonPhrase() {
+        return response.getStatusLine().getReasonPhrase();
+    }
+
+    @Override
     public boolean hasBody() {
         return (response.getEntity() != null);
     }

--- a/resources/sdk/purecloudjava/extensions/connector/okhttp/OkHttpResponse.java
+++ b/resources/sdk/purecloudjava/extensions/connector/okhttp/OkHttpResponse.java
@@ -23,6 +23,11 @@ public class OkHttpResponse implements ApiClientConnectorResponse {
     }
 
     @Override
+    public String getStatusReasonPhrase() {
+        return response.message();
+    }
+
+    @Override
     public Map<String, String> getHeaders() {
         Map<String, String> map = new HashMap<>();
         Headers headers = response.headers();

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -453,6 +453,7 @@ public class ApiClient implements AutoCloseable {
 
     private <T> ApiResponse<T> interpretConnectorResponse(ApiClientConnectorResponse response, TypeReference<T> returnType) throws Exception {
         int statusCode = response.getStatusCode();
+        String reasonPhrase = response.getStatusReasonPhrase();
         Map<String, String> headers = response.getHeaders();
 
         if (statusCode >= 200 && statusCode < 300) {
@@ -478,6 +479,11 @@ public class ApiClient implements AutoCloseable {
                 @Override
                 public Integer getStatusCode() {
                     return statusCode;
+                }
+
+                @Override
+                public String getStatusReasonPhrase() {
+                    return reasonPhrase;
                 }
 
                 @Override
@@ -978,6 +984,11 @@ public class ApiClient implements AutoCloseable {
         @Override
         public Integer getStatusCode() {
             return 500;
+        }
+
+        @Override
+        public String getStatusReasonPhrase() {
+            return exception.getMessage();
         }
 
         @Override


### PR DESCRIPTION
Adds the HTTP status reason phrase to the `ApiResponse<T>` interface.