### PR TITLE
Api 2274 exceptions

### DIFF
--- a/resources/sdk/purecloudjava/extensions/connector/ApiClientConnector.java
+++ b/resources/sdk/purecloudjava/extensions/connector/ApiClientConnector.java
@@ -2,9 +2,10 @@ package com.mypurecloud.sdk.v2.connector;
 
 import com.mypurecloud.sdk.v2.AsyncApiCallback;
 
+import java.io.IOException;
 import java.util.concurrent.Future;
 
 public interface ApiClientConnector extends AutoCloseable {
-    ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws Exception;
+    ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws IOException;
     Future<ApiClientConnectorResponse> invokeAsync(ApiClientConnectorRequest request, AsyncApiCallback<ApiClientConnectorResponse> callback);
 }

--- a/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpClientConnector.java
+++ b/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpClientConnector.java
@@ -5,6 +5,7 @@ import com.mypurecloud.sdk.v2.AsyncApiCallback;
 import com.mypurecloud.sdk.v2.connector.ApiClientConnector;
 import com.mypurecloud.sdk.v2.connector.ApiClientConnectorRequest;
 import com.mypurecloud.sdk.v2.connector.ApiClientConnectorResponse;
+import org.apache.http.MethodNotSupportedException;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -25,7 +26,7 @@ public class ApacheHttpClientConnector implements ApiClientConnector {
     }
 
     @Override
-    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws Exception {
+    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws IOException {
         // Build request object
         HttpUriRequest httpUriRequest;
         String method = request.getMethod();
@@ -34,6 +35,9 @@ public class ApacheHttpClientConnector implements ApiClientConnector {
 
         if ("GET".equals(method)) {
             HttpGet req = new HttpGet(url);
+            httpUriRequest = req;
+        } else if ("HEAD".equals(method)) {
+            HttpHead req = new HttpHead(url);
             httpUriRequest = req;
         } else if ("POST".equals(method)) {
             HttpPost req = new HttpPost(url);
@@ -57,7 +61,7 @@ public class ApacheHttpClientConnector implements ApiClientConnector {
             }
             httpUriRequest = req;
         } else {
-            throw new Exception("Unknown method type " + method);
+            throw new IllegalStateException("Unknown method type " + method);
         }
 
         for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {

--- a/resources/sdk/purecloudjava/extensions/connector/ning/AsyncHttpClientConnector.java
+++ b/resources/sdk/purecloudjava/extensions/connector/ning/AsyncHttpClientConnector.java
@@ -1,7 +1,6 @@
 package com.mypurecloud.sdk.v2.connector.ning;
 
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 import com.mypurecloud.sdk.v2.AsyncApiCallback;
 import com.mypurecloud.sdk.v2.connector.ApiClientConnector;
 import com.mypurecloud.sdk.v2.connector.ApiClientConnectorRequest;
@@ -9,7 +8,10 @@ import com.mypurecloud.sdk.v2.connector.ApiClientConnectorResponse;
 import org.asynchttpclient.*;
 import org.asynchttpclient.uri.Uri;
 
+import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 public class AsyncHttpClientConnector implements ApiClientConnector {
@@ -20,24 +22,57 @@ public class AsyncHttpClientConnector implements ApiClientConnector {
     }
 
     @Override
-    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws Exception {
-        return null;
+    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws IOException {
+        try {
+            Future<ApiClientConnectorResponse> future = invokeAsync(request, new AsyncApiCallback<ApiClientConnectorResponse>() {
+                @Override
+                public void onCompleted(ApiClientConnectorResponse response) { }
+
+                @Override
+                public void onFailed(Throwable exception) { }
+            });
+            return future.get();
+        }
+        catch (InterruptedException exception) {
+            throw new InterruptedIOException(exception.getMessage());
+        }
+        catch (ExecutionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException)cause;
+            }
+            throw new IOException(cause);
+        }
     }
 
     @Override
     public Future<ApiClientConnectorResponse> invokeAsync(ApiClientConnectorRequest request, AsyncApiCallback<ApiClientConnectorResponse> callback) {
 
         try {
+            String method = request.getMethod();
+
             RequestBuilder builder = new RequestBuilder()
                     .setUri(Uri.create(request.getUrl()))
-                    .setMethod(request.getMethod());
+                    .setMethod(method);
+
+            switch (method) {
+                case "GET":
+                case "HEAD":
+                case "DELETE":
+                    break;
+                case "POST":
+                case "PUT":
+                case "PATCH":
+                    if (request.hasBody()) {
+                        builder = builder.setBody(request.readBody());
+                    }
+                    break;
+                default:
+                    return Futures.immediateFailedFuture(new IllegalStateException("Unknown method type " + method));
+            }
 
             for (Map.Entry<String, String> header : request.getHeaders().entrySet()) {
                 builder = builder.addHeader(header.getKey(), header.getValue());
-            }
-
-            if (request.hasBody()) {
-                builder = builder.setBody(request.readBody());
             }
 
             return client.executeRequest(builder, new AsyncCompletionHandler<ApiClientConnectorResponse>() {

--- a/resources/sdk/purecloudjava/extensions/connector/okhttp/OkHttpClientConnector.java
+++ b/resources/sdk/purecloudjava/extensions/connector/okhttp/OkHttpClientConnector.java
@@ -19,7 +19,7 @@ public class OkHttpClientConnector implements ApiClientConnector {
     }
 
     @Override
-    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws Exception {
+    public ApiClientConnectorResponse invoke(ApiClientConnectorRequest request) throws IOException {
         Call call = client.newCall(buildRequest(request));
         return new OkHttpResponse(call.execute());
     }
@@ -51,7 +51,7 @@ public class OkHttpClientConnector implements ApiClientConnector {
         return future;
     }
 
-    private Request buildRequest(ApiClientConnectorRequest request) throws Exception {
+    private Request buildRequest(ApiClientConnectorRequest request) throws IOException {
         Request.Builder builder = new Request.Builder()
                 .url(request.getUrl());
 
@@ -66,6 +66,9 @@ public class OkHttpClientConnector implements ApiClientConnector {
         if ("GET".equals(method)) {
             builder = builder.get();
         }
+        else if ("HEAD".equals(method)) {
+            builder = builder.head();
+        }
         else if ("POST".equals(method)) {
             builder = builder.post(createBody(request));
         }
@@ -79,13 +82,13 @@ public class OkHttpClientConnector implements ApiClientConnector {
             builder = builder.patch(createBody(request));
         }
         else {
-            throw new Exception("Unknown method type " + method);
+            throw new IllegalStateException("Unknown method type " + method);
         }
 
         return builder.build();
     }
 
-    private RequestBody createBody(ApiClientConnectorRequest request) throws Exception {
+    private RequestBody createBody(ApiClientConnectorRequest request) throws IOException {
         String contentType = "application/json";
         Map<String, String> headers = request.getHeaders();
         if (headers != null && !headers.isEmpty()) {

--- a/resources/sdk/purecloudjava/extensions/extensions/notifications/NotificationHandler.java
+++ b/resources/sdk/purecloudjava/extensions/extensions/notifications/NotificationHandler.java
@@ -176,7 +176,7 @@ public class NotificationHandler extends Object {
         this.webSocketListener = webSocketListener;
     }
 
-    public <T> void addSubscription(NotificationListener<T> listener) throws ApiException {
+    public <T> void addSubscription(NotificationListener<T> listener) throws IOException, ApiException {
         // This condition exists because channels are automatically subscribed to channel.metadata when created
         if (!"channel.metadata".equals(listener.getTopic())) {
             ChannelTopic channelTopic = new ChannelTopic();
@@ -188,7 +188,7 @@ public class NotificationHandler extends Object {
         typeMap.put(listener.getTopic(), listener);
     }
 
-    public void RemoveSubscription(String topic) throws ApiException {
+    public void RemoveSubscription(String topic) throws IOException, ApiException {
         ChannelTopicEntityListing channels = notificationsApi.getNotificationsChannelSubscriptions(this.channel.getId());
         ChannelTopic match = null;
         for (ChannelTopic channelTopic : channels.getEntities()) {
@@ -203,7 +203,7 @@ public class NotificationHandler extends Object {
         typeMap.remove(topic);
     }
 
-    public void RemoveAllSubscriptions() throws ApiException {
+    public void RemoveAllSubscriptions() throws IOException, ApiException {
         notificationsApi.deleteNotificationsChannelSubscriptions(this.channel.getId());
         typeMap.clear();
     }

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -319,16 +319,12 @@ public class ApiClient implements AutoCloseable {
         }
     }
 
-    /**
+/**
      * Serialize the given Java object into string according the given
      * Content-Type (only JSON is supported for now).
      */
-    public String serialize(Object obj) throws ApiException {
-        try {
-            return objectMapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            throw new ApiException(e);
-        }
+    public String serialize(Object obj) throws IOException {
+        return objectMapper.writeValueAsString(obj);
     }
 
     /**
@@ -369,7 +365,7 @@ public class ApiClient implements AutoCloseable {
         return url.toString();
     }
 
-    private ApiClientConnectorRequest prepareConnectorRequest(ApiRequest<?> request) throws Exception {
+    private ApiClientConnectorRequest prepareConnectorRequest(ApiRequest<?> request) throws IOException {
         final String path = request.getPath();
         final List<Pair> queryParams = new ArrayList<>(request.getQueryParams());
 
@@ -406,7 +402,7 @@ public class ApiClient implements AutoCloseable {
         final Map<String, Object> formParams = request.getFormParams();
         final String serializedBody;
         if (body != null && !formParams.isEmpty()) {
-            throw new ApiException(500, "Cannot have body and form params");
+            throw new IllegalStateException("Request cannot have both form and body parameters.");
         }
         else if (body != null) {
             serializedBody = serialize(body);
@@ -451,7 +447,7 @@ public class ApiClient implements AutoCloseable {
         };
     }
 
-    private <T> ApiResponse<T> interpretConnectorResponse(ApiClientConnectorResponse response, TypeReference<T> returnType) throws Exception {
+    private <T> ApiResponse<T> interpretConnectorResponse(ApiClientConnectorResponse response, TypeReference<T> returnType) throws ApiException, IOException {
         int statusCode = response.getStatusCode();
         String reasonPhrase = response.getStatusReasonPhrase();
         Map<String, String> headers = response.getHeaders();
@@ -470,55 +466,7 @@ public class ApiClient implements AutoCloseable {
             else {
                 entity = null;
             }
-            return new ApiResponse<T>() {
-                @Override
-                public Exception getException() {
-                    return null;
-                }
-
-                @Override
-                public Integer getStatusCode() {
-                    return statusCode;
-                }
-
-                @Override
-                public String getStatusReasonPhrase() {
-                    return reasonPhrase;
-                }
-
-                @Override
-                public boolean hasRawBody() {
-                    return (body != null);
-                }
-
-                @Override
-                public String getRawBody() {
-                    return body;
-                }
-
-                @Override
-                public T getBody() {
-                    return entity;
-                }
-
-                @Override
-                public Map<String, String> getHeaders() {
-                    return headers;
-                }
-
-                @Override
-                public String getHeader(String key) {
-                    return headers.get(key);
-                }
-
-                @Override
-                public String getCorrelationId() {
-                    return getHeader("ININ-Correlation-ID");
-                }
-
-                @Override
-                public void close() throws Exception { }
-            };
+            return new ApiResponseWrapper<>(statusCode, reasonPhrase, headers, body, entity);
         }
         else {
             String message = "error";
@@ -527,10 +475,22 @@ public class ApiClient implements AutoCloseable {
         }
     }
 
-    private <T> ApiResponse<T> getAPIResponse(ApiRequest<?> request, TypeReference<T> returnType) throws Exception {
+    private <T> ApiResponse<T> getAPIResponse(ApiRequest<?> request, TypeReference<T> returnType) throws IOException, ApiException {
         ApiClientConnectorRequest connectorRequest = prepareConnectorRequest(request);
-        try (ApiClientConnectorResponse connectorResponse = connector.invoke(connectorRequest)) {
+        ApiClientConnectorResponse connectorResponse = null;
+        try {
+            connectorResponse = connector.invoke(connectorRequest);
             return interpretConnectorResponse(connectorResponse, returnType);
+        }
+        finally {
+            if (connectorResponse != null) {
+                try {
+                    connectorResponse.close();
+                }
+                catch (Throwable exception) {
+                    throw new RuntimeException(exception);
+                }
+            }
         }
     }
 
@@ -967,6 +927,70 @@ public class ApiClient implements AutoCloseable {
         public String[] getAuthNames() {
             return authNames;
         }
+    }
+
+    private static class ApiResponseWrapper<T> implements ApiResponse<T> {
+        private final int statusCode;
+        private final String reasonPhrase;
+        private final Map<String, String> headers;
+        private final String body;
+        private final T entity;
+
+        public ApiResponseWrapper(int statusCode, String reasonPhrase, Map<String, String> headers, String body, T entity) {
+            this.statusCode = statusCode;
+            this.reasonPhrase = reasonPhrase;
+            this.headers = Collections.unmodifiableMap(headers);
+            this.body = body;
+            this.entity = entity;
+        }
+
+        @Override
+        public Exception getException() {
+            return null;
+        }
+
+        @Override
+        public Integer getStatusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public String getStatusReasonPhrase() {
+            return reasonPhrase;
+        }
+
+        @Override
+        public boolean hasRawBody() {
+            return (body != null && !body.isEmpty());
+        }
+
+        @Override
+        public String getRawBody() {
+            return body;
+        }
+
+        @Override
+        public T getBody() {
+            return entity;
+        }
+
+        @Override
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public String getHeader(String key) {
+            return headers.get(key);
+        }
+
+        @Override
+        public String getCorrelationId() {
+            return headers.get("ININ-Correlation-ID");
+        }
+
+        @Override
+        public void close() throws Exception { }
     }
 
     private static class ApiExceptionResponse<T> implements ApiResponse<T> {

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -572,48 +572,55 @@ public class ApiClient implements AutoCloseable {
      * @param authNames    The authentications to apply
      * @return The response body in type of string
      */
-    public <T> ApiResponse<T> invokeAPIVerbose(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException {
+    public <T> ApiResponse<T> invokeAPIVerbose(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException, IOException {
         return invokeAPIVerbose(new ApiRequestWrapper<>(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames), returnType);
     }
 
-    public <T> ApiResponse<T> invokeAPIVerbose(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException {
+    public <T> ApiResponse<T> invokeAPIVerbose(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException, IOException {
         try {
             return getAPIResponse(request, returnType);
         }
-        catch (Exception exception) {
+        catch (ApiException exception) {
+            @SuppressWarnings("unchecked")
+            ApiResponse<T> response = (ApiResponse<T>)exception;
+            return response;
+        }
+        catch (Throwable exception) {
             if (shouldThrowErrors) {
-                if (exception instanceof ApiException) {
-                    throw (ApiException)exception;
+                if (exception instanceof IOException) {
+                    throw (IOException) exception;
                 }
-                throw new ApiException(exception);
+                throw new IOException("Failed to complete HTTP request.", exception);
             }
             return new ApiExceptionResponse<>(exception);
         }
     }
 
     public <T> Future<ApiResponse<T>> invokeAPIVerboseAsync(ApiRequest<?> request, TypeReference<T> returnType, AsyncApiCallback<ApiResponse<T>> callback) {
-        if (shouldThrowErrors) {
-            return getAPIResponseAsync(request, returnType, callback);
-        }
-        else {
-            SettableFuture<ApiResponse<T>> future = SettableFuture.create();
-            getAPIResponseAsync(request, returnType, new AsyncApiCallback<ApiResponse<T>>() {
-                @Override
-                public void onCompleted(ApiResponse<T> response) {
+        SettableFuture<ApiResponse<T>> future = SettableFuture.create();
+        getAPIResponseAsync(request, returnType, new AsyncApiCallback<ApiResponse<T>>() {
+            @Override
+            public void onCompleted(ApiResponse<T> response) {
+                notifySuccess(future, callback, response);
+            }
+
+            @Override
+            public void onFailed(Throwable exception) {
+                if (exception instanceof ApiException) {
+                    @SuppressWarnings("unchecked")
+                    ApiResponse<T> response = (ApiResponse<T>)exception;
                     notifySuccess(future, callback, response);
                 }
-
-                @Override
-                public void onFailed(Throwable exception) {
-                    if (!(exception instanceof Exception)) {
-                        exception = new ExecutionException(exception);
-
-                    }
-                    notifySuccess(future, callback, new ApiExceptionResponse<>((Exception)exception));
+                else if (shouldThrowErrors) {
+                    notifyFailure(future, callback, exception);
                 }
-            });
-            return future;
-        }
+                else {
+                    notifySuccess(future, callback, new ApiExceptionResponse<>(exception));
+
+                }
+            }
+        });
+        return future;
     }
 
     /**
@@ -630,7 +637,7 @@ public class ApiClient implements AutoCloseable {
      * @param authNames    The authentications to apply
      * @return The response body in type of string
      */
-    public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException {
+    public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException, IOException {
         T response = null;
         try {
             response = invokeAPIVerbose(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames, returnType).getBody();
@@ -649,7 +656,7 @@ public class ApiClient implements AutoCloseable {
      * @param request The request object
      * @return The response body in type of string
      */
-    public <T> T invokeAPI(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException {
+    public <T> T invokeAPI(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException, IOException {
         T response = null;
         try {
             response = invokeAPIVerbose(request, returnType).getBody();
@@ -672,7 +679,7 @@ public class ApiClient implements AutoCloseable {
 
             @Override
             public void onFailed(Throwable exception) {
-                notifySuccess(future, callback, null);
+                notifyFailure(future, callback, exception);
             }
         });
         return future;
@@ -996,8 +1003,8 @@ public class ApiClient implements AutoCloseable {
     private static class ApiExceptionResponse<T> implements ApiResponse<T> {
         private final Exception exception;
 
-        public ApiExceptionResponse(Exception exception) {
-            this.exception = exception;
+        public ApiExceptionResponse(Throwable exception) {
+            this.exception = (exception instanceof Exception) ? (Exception)exception : new RuntimeException(exception);
         }
 
         @Override

--- a/resources/sdk/purecloudjava/templates/api.mustache
+++ b/resources/sdk/purecloudjava/templates/api.mustache
@@ -16,6 +16,7 @@ import {{invokerPackage}}.Pair;
 {{#operations}}{{#operation}}
 import {{package}}.request.{{requestClassname}};{{/operation}}{{/operations}}
 
+import java.io.IOException;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public class {{classname}} {
    * @return {{{returnType}}}{{/returnType}}
    * @throws ApiException if fails to make API call
    */
-  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
     {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}.getBody(){{/returnType}};
   }
 
@@ -55,12 +56,12 @@ public class {{classname}} {
    * @return {{{returnType}}}{{/returnType}}
    * @throws ApiException if fails to make API call
    */
-  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set
     if ({{paramName}} == null) {
-      throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+      throw new IllegalArgumentException("Missing the required parameter '{{paramName}}' when calling {{operationId}}");
     }
     {{/required}}{{/allParams}}
     // create path and map variables
@@ -105,7 +106,7 @@ public class {{classname}} {
    * @request The request object
    * @throws ApiException if fails to make API call
    */
-  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{requestClassname}} request) throws ApiException {
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{requestClassname}} request) throws IOException, ApiException {
     {{#returnType}}return {{/returnType}}{{localVariablePrefix}}apiClient.invokeAPI(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
   }
 
@@ -115,7 +116,7 @@ public class {{classname}} {
    * @request The request object
    * @throws ApiException if fails to make API call
    */
-  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request) throws ApiException {
+  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request) throws IOException, ApiException {
     return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIVerbose(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
   }
 

--- a/resources/sdk/purecloudjava/templates/apiException.mustache
+++ b/resources/sdk/purecloudjava/templates/apiException.mustache
@@ -1,69 +1,66 @@
 package {{invokerPackage}};
 
+import java.util.Collections;
 import java.util.Map;
-import java.util.List;
 
 {{>generatedAnnotation}}
-public class ApiException extends Exception {
-  private int code = 0;
-  private Map<String, String> responseHeaders = null;
-  private String responseBody = null;
+public class ApiException extends Exception implements ApiResponse<Object> {
+    private final int statusCode;
+    private final Map<String, String> headers;
+    private final String body;
 
-  public ApiException() {}
+    public ApiException(int statusCode, String message, Map<String, String> headers, String body) {
+        super(message);
+        this.statusCode = statusCode;
+        this.headers = Collections.unmodifiableMap(headers);
+        this.body = body;
+    }
 
-  public ApiException(Throwable throwable) {
-    super(throwable);
-  }
+    @Override
+    public Exception getException() {
+        return this;
+    }
 
-  public ApiException(String message) {
-    super(message);
-  }
+    @Override
+    public Integer getStatusCode() {
+        return statusCode;
+    }
 
-  public ApiException(String message, Throwable throwable, int code, Map<String, String> responseHeaders, String responseBody) {
-    super(message, throwable);
-    this.code = code;
-    this.responseHeaders = responseHeaders;
-    this.responseBody = responseBody;
-  }
+    @Override
+    public String getStatusReasonPhrase() {
+        return getMessage();
+    }
 
-  public ApiException(String message, int code, Map<String, String> responseHeaders, String responseBody) {
-    this(message, (Throwable) null, code, responseHeaders, responseBody);
-  }
+    @Override
+    public boolean hasRawBody() {
+        return (body != null && !body.isEmpty());
+    }
 
-  public ApiException(String message, Throwable throwable, int code, Map<String, String> responseHeaders) {
-    this(message, throwable, code, responseHeaders, null);
-  }
+    @Override
+    public String getRawBody() {
+        return body;
+    }
 
-  public ApiException(int code, Map<String, String> responseHeaders, String responseBody) {
-    this((String) null, (Throwable) null, code, responseHeaders, responseBody);
-  }
+    @Override
+    public Object getBody() {
+        return null;
+    }
 
-  public ApiException(int code, String message) {
-    super(message);
-    this.code = code;
-  }
+    @Override
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
 
-  public ApiException(int code, String message, Map<String, String> responseHeaders, String responseBody) {
-    this(code, message);
-    this.responseHeaders = responseHeaders;
-    this.responseBody = responseBody;
-  }
+    @Override
+    public String getHeader(String key) {
+        return headers.get(key);
+    }
 
-  public int getCode() {
-    return code;
-  }
+    @Override
+    public String getCorrelationId() {
+        return getHeader("ININ-Correlation-ID");
+    }
 
-  /**
-   * Get the HTTP response headers.
-   */
-  public Map<String, String> getResponseHeaders() {
-    return responseHeaders;
-  }
-
-  /**
-   * Get the HTTP response body.
-   */
-  public String getResponseBody() {
-    return responseBody;
-  }
+    @Override
+    public void close() throws Exception { }
 }

--- a/resources/sdk/purecloudjava/templates/api_async.mustache
+++ b/resources/sdk/purecloudjava/templates/api_async.mustache
@@ -17,6 +17,7 @@ import {{invokerPackage}}.Pair;
 {{#operations}}{{#operation}}
 import {{package}}.request.{{requestClassname}};{{/operation}}{{/operations}}
 
+import java.io.IOException;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,7 +46,7 @@ public class {{classname}}Async {
    * @request The request object
    * @throws ApiException if fails to make API call
    */
-  public Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}Async({{requestClassname}} request, AsyncApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> callback) throws ApiException {
+  public Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}Async({{requestClassname}} request, AsyncApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> callback) {
     return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIAsync(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, callback);
   }
 
@@ -55,7 +56,7 @@ public class {{classname}}Async {
    * @request The request object
    * @throws ApiException if fails to make API call
    */
-  public Future<{{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}}> {{operationId}}Async(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request, AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> callback) throws ApiException {
+  public Future<{{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}}> {{operationId}}Async(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request, AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> callback) {
     return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIVerboseAsync(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, callback);
   }
 

--- a/resources/sdk/purecloudjava/templates/requestBuilder.mustache
+++ b/resources/sdk/purecloudjava/templates/requestBuilder.mustache
@@ -61,11 +61,11 @@ public class {{requestClassname}} {
         return this;
     }
 
-    public ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> withHttpInfo() throws ApiException {
+    public ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> withHttpInfo() {
         {{#allParams}}{{#required}}
         // verify the required parameter '{{paramName}}' is set
         if (this.{{paramName}} == null) {
-            throw new ApiException(400, "Missing the required parameter '{{paramName}}' when building request for {{classname}}.");
+            throw new IllegalStateException("Missing the required parameter '{{paramName}}' when building request for {{classname}}.");
         }
         {{/required}}{{/allParams}}
 


### PR DESCRIPTION
This should implement exception handling as discussed:

* The vanilla methods should throw exceptions for non-2xx response and rethrow caught exceptions without encapsulating them
* The extended methods should set non-2xx exceptions on the ApiResponse object and rethrow caught exceptions without encapsulating them
* The ability to suppress all exceptions will remain. This will cause vanilla methods to return null and the extended methods to return the exception as part of the ApiResponse object if any exception occurs