### PR TITLE
Api 2464

### DIFF
--- a/resources/sdk/purecloudjava/extensions/ApiResponse.java
+++ b/resources/sdk/purecloudjava/extensions/ApiResponse.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public interface ApiResponse<T> extends AutoCloseable {
     Exception getException();
-    Integer getStatusCode();
+    int getStatusCode();
     String getStatusReasonPhrase();
     boolean hasRawBody();
     String getRawBody();

--- a/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpResponse.java
+++ b/resources/sdk/purecloudjava/extensions/connector/apache/ApacheHttpResponse.java
@@ -20,14 +20,15 @@ class ApacheHttpResponse implements ApiClientConnectorResponse {
 
     public ApacheHttpResponse(CloseableHttpResponse response) {
         this.response = response;
-
         HttpEntity entity = response.getEntity();
-        if (!entity.isRepeatable()) {
-            try {
-                response.setEntity(new BufferedHttpEntity(entity));
-            }
-            catch (Exception exception) {
-                LOG.error("Failed to buffer HTTP entity.", exception);
+        if (entity != null) {
+            if (!entity.isRepeatable()) {
+                try {
+                    response.setEntity(new BufferedHttpEntity(entity));
+                }
+                catch (Exception exception) {
+                    LOG.error("Failed to buffer HTTP entity.", exception);
+                }
             }
         }
     }
@@ -44,7 +45,8 @@ class ApacheHttpResponse implements ApiClientConnectorResponse {
 
     @Override
     public boolean hasBody() {
-        return (response.getEntity() != null);
+        HttpEntity entity = response.getEntity();
+        return (entity != null && entity.getContentLength() != 0L);
     }
 
     @Override

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -841,7 +841,7 @@ public class ApiClient implements AutoCloseable {
         }
 
         @Override
-        public Integer getStatusCode() {
+        public int getStatusCode() {
             return statusCode;
         }
 

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -454,18 +454,13 @@ public class ApiClient implements AutoCloseable {
         Map<String, String> headers = response.getHeaders();
 
         if (statusCode >= 200 && statusCode < 300) {
-            String body = response.readBody();
-            final T entity;
-            if (statusCode != 204 && body != null && returnType != null) {
-                if (returnType.getType() != Void.class) {
+            String body = null;
+            T entity = null;
+            if (statusCode != 204 && returnType != null && returnType.getType() != Void.class && response.hasBody()) {
+                body = response.readBody();
+                if (body != null && body.length() > 0) {
                     entity = objectMapper.readValue(body, returnType);
                 }
-                else {
-                    entity = null;
-                }
-            }
-            else {
-                entity = null;
             }
             return new ApiResponseWrapper<>(statusCode, reasonPhrase, headers, body, entity);
         }

--- a/resources/sdk/purecloudjava/templates/apiException.mustache
+++ b/resources/sdk/purecloudjava/templates/apiException.mustache
@@ -5,7 +5,7 @@ import java.util.Map;
 
 {{>generatedAnnotation}}
 public class ApiException extends Exception implements ApiResponse<Object> {
-    private final Integer statusCode;
+    private final int statusCode;
     private final Map<String, String> headers;
     private final String body;
 
@@ -18,7 +18,7 @@ public class ApiException extends Exception implements ApiResponse<Object> {
 
     public ApiException(Throwable cause) {
         super(cause);
-        this.statusCode = null;
+        this.statusCode = -1;
         this.headers = Collections.emptyMap();
         this.body = null;
     }
@@ -29,7 +29,7 @@ public class ApiException extends Exception implements ApiResponse<Object> {
     }
 
     @Override
-    public Integer getStatusCode() {
+    public int getStatusCode() {
         return statusCode;
     }
 


### PR DESCRIPTION
Improves handling of empty response bodies by not attempting to deserialize them.  Changes `ApiResponse::getStatusCode` back to returning an `int` instead of an `Integer`.