### PR TITLE
Correct casing of correlation id header name.

### DIFF
--- a/resources/sdk/purecloudjava/templates/apiException.mustache
+++ b/resources/sdk/purecloudjava/templates/apiException.mustache
@@ -65,7 +65,7 @@ public class ApiException extends Exception implements ApiResponse<Object> {
 
     @Override
     public String getCorrelationId() {
-        return getHeader("ININ-Correlation-ID");
+        return getHeader("ININ-Correlation-Id");
     }
 
     @Override


### PR DESCRIPTION
API returns this casing:
```
Date: Mon, 08 Jul 2019 16:05:37 GMT
Expires: 0
ININ-Correlation-Id: 6fcf53ef-5402-4c23-921e-d67576d39409
```

Testing with an exception catch and `e.getCorrelationId` and `e.getHeader("ININ-Correlation-Id")` side by side results in a null for the former and the correct value for the latter.