### PR TITLE
Adding clientcredential helperand saml2bearer helper

### DIFF
--- a/resources/sdk/purecloudpython/scripts/SdkTests.py
+++ b/resources/sdk/purecloudpython/scripts/SdkTests.py
@@ -52,31 +52,9 @@ class SdkTests(unittest.TestCase):
 			PureCloudPlatformClientV2.configuration.host = 'https://api.%s' % (environment)
 			print("Environment not found in PureCloudRegionHosts defaulting to string value")
 		
-		
-
-		# Base64 encode the client ID and client secret
-		authorization = base64.b64encode('%s:%s' % (os.environ.get('PURECLOUD_CLIENT_ID'), os.environ.get('PURECLOUD_CLIENT_SECRET')))
-
-		# Prepare for POST /oauth/token request
-		requestHeaders = {
-			'Authorization': 'Basic ' + authorization,
-			'Content-Type': 'application/x-www-form-urlencoded'
-		}
-		requestBody = {
-			'grant_type': 'client_credentials'
-		}
-
-		# Get token
-		response = requests.post('https://login.%s/oauth/token' % (os.environ.get('PURECLOUD_ENVIRONMENT')), data=requestBody, headers=requestHeaders)
-
-		# Check response
-		self.assertEqual(response.status_code, 200)
-
-		# Set token on SDK
-		responseJson = response.json()
-		self.assertIsNotNone(responseJson['access_token'])
-		PureCloudPlatformClientV2.configuration.access_token = responseJson['access_token']
-		SdkTests.users_api = PureCloudPlatformClientV2.UsersApi()
+	    # Authenticate with client credentials and pass the apiclient instance into the usersapi
+		apiclient = PureCloudPlatformClientV2.api_client.ApiClient().get_client_credentials_token(os.environ.get('PURECLOUD_CLIENT_ID'), os.environ.get('PURECLOUD_CLIENT_SECRET'))
+		SdkTests.users_api = PureCloudPlatformClientV2.UsersApi(apiclient)
 
 	def test_3_create_user(self):
 		body = PureCloudPlatformClientV2.CreateUser()

--- a/resources/sdk/purecloudpython/templates/README.mustache
+++ b/resources/sdk/purecloudpython/templates/README.mustache
@@ -26,11 +26,34 @@ import PureCloudPlatformClientV2
 
 ### Authenticating
 
-The Python SDK does not currently contain helper methods to complete an OAuth flow. The consuming applicaiton must complete an OAuth flow to get an access token outside the scope of the SDK. Once an access token is obtained, it should be set on the SDK via `PureCloudPlatformClientV2.configuration.access_token`. For more information about authenticating with OAuth, see the Developer Center article [Authorization](https://developer.mypurecloud.com/api/rest/authorization/index.html).
+#### Client Credentials Grant
+
+**Use when...**
+
+* The app is authenticating as a non-human (e.g. a service, scheduled task, or other non-UI application)
+
+For headless and non-user applications, the [Client Credentials Grant](http://developer.mypurecloud.com/api/rest/authorization/use-client-credentials.html) 
 
 ```{"language":"python"}
-PureCloudPlatformClientV2.configuration.access_token = 'cuQbSAf1LU4CuIaSj1D6Gm399jmTr7zLTTc3KPSyCvEyJQIo9r648h3SH8oFzLPPKxE3Mvb166lq5NcjSBoGE5A'
+apiclient = PureCloudPlatformClientV2.api_client.ApiClient().get_client_credentials_token("7de3af06-c0b3-4f9b-af45-72f4a14037cc", "qLh-825gtjPrIY2kcWKAkmlaSgi6Z1Ws2BAyixWbTrs")
+authApi = PureCloudPlatformClientV2.AuthorizationApi(apiclient)
+print authApi.get_authorization_permissions()
 ```
+
+#### OAuth2 SAML2 Bearer Grant
+
+**Use when...**
+
+* The app is authenticating as a human user, the [OAuth2 SAML2 Bearer](https://developer.mypurecloud.com/api/rest/authorization/use-saml2-bearer.html)
+
+```{"language":"python"}
+apiclient = PureCloudPlatformClientV2.api_client.ApiClient().get_saml2bearer_token("565c3091-4107-4675-b606-b1fead2d15a4", "9pal483eSr_vCZf0qQomFK298I8htjBZo49FI_lLZQ8", orgName ,encodedsamlassertion)
+usersApi = PureCloudPlatformClientV2.UsersApi(apiclient)
+print usersApi.get_users_me()
+
+```
+
+
 
 ### Setting the Environment
 

--- a/resources/sdk/purecloudpython/templates/api_client.mustache
+++ b/resources/sdk/purecloudpython/templates/api_client.mustache
@@ -32,6 +32,9 @@ import mimetypes
 import random
 import tempfile
 import threading
+import base64
+import json
+
 
 from datetime import datetime
 from datetime import date
@@ -86,6 +89,74 @@ class ApiClient(object):
         # access token for OAuth
         self.access_token = ""
 {{/isOAuth}}{{/authMethods}}
+
+
+    def get_client_credentials_token(self, client_id, client_secret):
+        """
+        :param client_id: Client ID to authenticate with
+        :param client_secret: Client Secret to Authenticate with
+        :return: Returns the Api Object which allows this to directly enter into an api call, also sets the token
+        """
+        query_params = {}
+        body = None
+        host = (self.host).split('.', 2)[1]
+        url = 'https://login.' + host + '.com/oauth/token'
+
+        post_params = {'grant_type': 'client_credentials'}
+
+        auth_string = 'Basic ' + base64.b64encode(bytes((client_id + ':' + client_secret).encode('ascii'))).decode(
+            'ascii')
+
+        header_params = {
+            "Authorization": auth_string,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        header_params = self.sanitize_for_serialization(header_params)
+        post_params = self.sanitize_for_serialization(post_params)
+
+        response = self.request("POST", url,
+                                query_params=query_params,
+                                headers=header_params,
+                                post_params=post_params, body=body);
+        data = json.loads('[' + response.data + ']')
+        self.access_token = data[0]["access_token"]
+        return self;
+
+    def get_saml2bearer_token(self,client_id,client_secret,org_name,assertion):
+        """:param client_id: Client Id to authenticate with
+         :param client_secret: Client Secret to authenticate with
+         :param org_name: Orginization name to authenticate with
+         :param assertion: SamlAssertion encoded
+         :return:
+         """
+
+        query_params = {}
+        body = None
+        host = (self.host).split('.', 2)[1]
+        url = 'https://login.' + host + '.com/oauth/token'
+
+        post_params = {'grant_type': 'urn:ietf:params:oauth:grant-type:saml2-bearer',
+                       'orgName': org_name,
+                       'assertion': assertion
+                       }
+
+        auth_string = 'Basic ' + base64.b64encode(bytes((client_id + ':' + client_secret).encode('ascii'))).decode(
+            'ascii')
+
+        header_params = {
+            "Authorization": auth_string,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        header_params = self.sanitize_for_serialization(header_params)
+        post_params = self.sanitize_for_serialization(post_params)
+
+        response = self.request("POST", url,
+                                query_params=query_params,
+                                headers=header_params,
+                                post_params=post_params, body=body);
+        data = json.loads('[' + response.data + ']')
+        self.access_token = data[0]["access_token"]
+        return self;  
 
     @property
     def user_agent(self):


### PR DESCRIPTION
Updated python to include both a client credential helper and saml2bearer helper. The application flow works as such you use the authentication function with creates an api instance and sets the token in that instance. You then pass that api instance into the calling classes to make calls from there