### PR TITLE
Use generic object for `results` field in `api/v2/search`

### DIFF
--- a/resources/sdk/purecloudpython/templates/api_client.mustache
+++ b/resources/sdk/purecloudpython/templates/api_client.mustache
@@ -646,6 +646,12 @@ class ApiClient(object):
         :param klass: class literal.
         :return: model object.
         """
+
+        # ArrayNode used in /api/v2/search is generic
+        # return the loaded json as is
+        if type(instance).__name__ == 'ArrayNode':
+            return data
+
         instance = klass()
 
         for attr, attr_type in iteritems(instance.swagger_types):


### PR DESCRIPTION
The `result` field is typed with `ArrayNode` but it's response is generic and can not be strictly typed. So we use the result from `json.loads` directly instead of deserializing it with `ArrayNode` definition.