### PR TITLE
API 5201 - Add new regions to SDKs

### DIFF
--- a/resources/sdk/pureclouddotnet/extensions/Client/PureCloudRegionHosts.cs
+++ b/resources/sdk/pureclouddotnet/extensions/Client/PureCloudRegionHosts.cs
@@ -20,7 +20,15 @@ namespace {{=it.packageName}}.Client
         [Description("https://api.mypurecloud.jp")]
         ap_northeast_1,
         [Description("https://api.mypurecloud.com.au")]
-        ap_southeast_1
+        ap_southeast_1,
+        [Description("https://usw2.pure.cloud")]
+        us_west_2,
+        [Description("https://cac1.pure.cloud")]
+        ca_central_1,
+        [Description("https://apne2.pure.cloud")]
+        ap_northeast_2,
+        [Description("https://euw2.pure.cloud")]
+        eu_west_2
 
     }
 

--- a/resources/sdk/pureclouddotnet/templates/test-SdkTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-SdkTests.mustache
@@ -225,6 +225,14 @@ namespace {{packageName}}.Tests
                  return PureCloudRegionHosts.ap_northeast_1;
                 case "mypurecloud.com.au":
                  return PureCloudRegionHosts.ap_southeast_1;
+                case "usw2.pure.cloud":
+                 return PureCloudRegionHosts.us_west_2;
+                case "cac1.pure.cloud":
+                 return PureCloudRegionHosts.ca_central_1;
+                case "apne2.pure.cloud":
+                 return PureCloudRegionHosts.ap_northeast_2;
+                case "euw2.pure.cloud":
+                 return PureCloudRegionHosts.eu_west_2;
                 default:
                  Console.WriteLine("Value does not exist in enum using default val");
                  return null;

--- a/resources/sdk/purecloudjava-guest/extensions/PureCloudRegionHosts.java
+++ b/resources/sdk/purecloudjava-guest/extensions/PureCloudRegionHosts.java
@@ -5,7 +5,11 @@ public enum PureCloudRegionHosts {
     eu_west_1("https://api.mypurecloud.ie"),
     ap_southeast_2( "https://api.mypurecloud.com.au"),
     ap_northeast_1("https://api.mypurecloud.jp"),
-    eu_central_1("https://api.mypurecloud.de");
+    eu_central_1("https://api.mypurecloud.de"),
+    us_west_2("https://usw2.pure.cloud"),
+    ca_central_1("https://cac1.pure.cloud"),
+    ap_northeast_2("https://apne2.pure.cloud"),
+    eu_west_2("https://euw2.pure.cloud");
 
 
     private String apiHost;

--- a/resources/sdk/purecloudjava/extensions/PureCloudRegionHosts.java
+++ b/resources/sdk/purecloudjava/extensions/PureCloudRegionHosts.java
@@ -5,7 +5,11 @@ public enum PureCloudRegionHosts {
     eu_west_1("https://api.mypurecloud.ie"),
     ap_southeast_2( "https://api.mypurecloud.com.au"),
     ap_northeast_1("https://api.mypurecloud.jp"),
-    eu_central_1("https://api.mypurecloud.de");
+    eu_central_1("https://api.mypurecloud.de"),
+    us_west_2("https://usw2.pure.cloud"),
+    ca_central_1("https://cac1.pure.cloud"),
+    ap_northeast_2("https://apne2.pure.cloud"),
+    eu_west_2("https://euw2.pure.cloud");
 
 
     private String apiHost;

--- a/resources/sdk/purecloudjava/tests/SdkTests.java
+++ b/resources/sdk/purecloudjava/tests/SdkTests.java
@@ -242,6 +242,14 @@ public class SdkTests {
                 return PureCloudRegionHosts.ap_northeast_1;
             case "mypurecloud.de":
                 return PureCloudRegionHosts.eu_central_1;
+            case "usw2.pure.cloud":
+                return PureCloudRegionHosts.us_west_2;
+            case "cac1.pure.cloud":
+                return PureCloudRegionHosts.ca_central_1;
+            case "apne2.pure.cloud":
+                return PureCloudRegionHosts.ap_northeast_2;
+            case "euw2.pure.cloud":
+                return PureCloudRegionHosts.eu_west_2;
             default:
                 System.out.println("Not in PureCloudRegionHosts using string value");
                 return null;

--- a/resources/sdk/purecloudjavascript-guest/extensions/PureCloudRegionHosts.js
+++ b/resources/sdk/purecloudjavascript-guest/extensions/PureCloudRegionHosts.js
@@ -3,6 +3,10 @@ export default  {
     eu_west_1: "mypurecloud.ie",
     ap_southeast_2: "mypurecloud.com.au", 
     ap_northeast_1: "mypurecloud.jp",
-    eu_central_1: "mypurecloud.de"
+    eu_central_1: "mypurecloud.de",
+    us_west_2: "usw2.pure.cloud",
+    ca_central_1: "cac1.pure.cloud",
+    ap_northeast_2: "apne2.pure.cloud",
+    eu_west_2: "euw2.pure.cloud"
    }
    

--- a/resources/sdk/purecloudjavascript/extensions/PureCloudRegionHosts.js
+++ b/resources/sdk/purecloudjavascript/extensions/PureCloudRegionHosts.js
@@ -3,6 +3,10 @@ export default  {
     eu_west_1: "mypurecloud.ie",
     ap_southeast_2: "mypurecloud.com.au", 
     ap_northeast_1: "mypurecloud.jp",
-    eu_central_1: "mypurecloud.de"
+    eu_central_1: "mypurecloud.de",
+    us_west_2: "usw2.pure.cloud",
+    ca_central_1: "cac1.pure.cloud",
+    ap_northeast_2: "apne2.pure.cloud",
+    eu_west_2: "euw2.pure.cloud"
    }
    

--- a/resources/sdk/purecloudjavascript/scripts/test/index.js
+++ b/resources/sdk/purecloudjavascript/scripts/test/index.js
@@ -141,7 +141,14 @@ function setEnvironment() {
         return platformClient.PureCloudRegionHosts.ap_northeast_1;
       case "mypurecloud.de":
         return platformClient.PureCloudRegionHosts.eu_central_1;
-  
+      case "usw2.pure.cloud":
+        return platformClient.PureCloudRegionHosts.us_west_2;
+      case "cac1.pure.cloud":
+        return platformClient.PureCloudRegionHosts.ca_central_1;
+      case "apne2.pure.cloud":
+        return platformClient.PureCloudRegionHosts.ap_northeast_2;
+      case "euw2.pure.cloud":
+        return platformClient.PureCloudRegionHosts.eu_west_2;
       default:
         console.log(
           "Value does not exist in PureCloudRegionHosts defaulting to PURECLOUD ENVIRONMENT value"

--- a/resources/sdk/purecloudpython/extensions/purecloud_region_hosts.py
+++ b/resources/sdk/purecloudpython/extensions/purecloud_region_hosts.py
@@ -7,6 +7,10 @@ class PureCloudRegionHosts(Enum):
     ap_southeast_2 = "https://api.mypurecloud.com.au"
     ap_northeast_1 = "https://api.mypurecloud.jp"
     eu_central_1 = "https://api.mypurecloud.de"
+    us_west_2 = "https://usw2.pure.cloud"
+    ca_central_1 = "https://cac1.pure.cloud"
+    ap_northeast_2 = "https://apne2.pure.cloud"
+    eu_west_2 = "https://euw2.pure.cloud"
 
     def __init__(self, apihost):
         self.apihost = apihost

--- a/resources/sdk/purecloudpython/scripts/SdkTests.py
+++ b/resources/sdk/purecloudpython/scripts/SdkTests.py
@@ -144,7 +144,11 @@ class SdkTests(unittest.TestCase):
 			'mypurecloud.ie': PureCloudPlatformClientV2.PureCloudRegionHosts.eu_west_1,
 			'mypurecloud.com.au': PureCloudPlatformClientV2.PureCloudRegionHosts.ap_southeast_2,
 			'mypurecloud.jp': PureCloudPlatformClientV2.PureCloudRegionHosts.ap_northeast_1,
-			'eu_central_1': PureCloudPlatformClientV2.PureCloudRegionHosts.eu_central_1
+			'mypurecloud.de': PureCloudPlatformClientV2.PureCloudRegionHosts.eu_central_1,
+			'usw2.pure.cloud': PureCloudPlatformClientV2.PureCloudRegionHosts.us_west_2,
+			'cac1.pure.cloud': PureCloudPlatformClientV2.PureCloudRegionHosts.ca_central_1,
+			'apne2.pure.cloud': PureCloudPlatformClientV2.PureCloudRegionHosts.ap_northeast_2,
+			'euw2.pure.cloud': PureCloudPlatformClientV2.PureCloudRegionHosts.eu_west_2
 			}.get(x,x)
 
 


### PR DESCRIPTION
Adding the following regions to the SDKs:
- us_west_2 - usw2.pure.cloud
- ca_central_1 - cac1.pure.cloud
- ap_northeast_2 - apne2.pure.cloud
- eu-west-2 - euw2.pure.cloud