### PR TITLE
API-5107 Add retry logic to the .NET SDK

### DIFF
--- a/resources/sdk/pureclouddotnet/scripts/compile.sh
+++ b/resources/sdk/pureclouddotnet/scripts/compile.sh
@@ -30,6 +30,10 @@ cp $BUILD_DIR/packages/Newtonsoft.Json.11.0.2/lib/net45/Newtonsoft.Json.dll $BUI
 cp $BUILD_DIR/packages/RestSharp.106.3.1/lib/net452/RestSharp.dll $BUILD_DIR/bin/RestSharp.dll;
 cp $BUILD_DIR/packages/WebSocketSharp.1.0.3-rc11/lib/websocket-sharp.dll $BUILD_DIR/bin/websocket-sharp.dll;
 cp $BUILD_DIR/packages/NUnit.3.10.1/lib/net45/nunit.framework.dll $BUILD_DIR/bin/nunit.framework.dll;
+cp $BUILD_DIR/packages/Moq.4.13.1/lib/net45/Moq.dll $BUILD_DIR/bin/Moq.dll;
+cp $BUILD_DIR/packages/Castle.Core.4.4.0/lib/net45/Castle.Core.dll $BUILD_DIR/bin/Castle.Core.dll;
+cp $BUILD_DIR/packages/System.Threading.Tasks.Extensions.4.5.1/lib/netstandard1.0/System.Threading.Tasks.Extensions.dll $BUILD_DIR/bin/System.Threading.Tasks.Extensions.dll;
+cp $BUILD_DIR/packages/System.Runtime.CompilerServices.Unsafe.4.5.0/lib/netstandard1.0/System.Runtime.CompilerServices.Unsafe.dll $BUILD_DIR/bin/System.Runtime.CompilerServices.Unsafe.dll;
 
 echo "Compiling SDK..."
 mcs -r:$BUILD_DIR/bin/Newtonsoft.Json.dll,\
@@ -48,7 +52,8 @@ $BUILD_DIR/bin/RestSharp.dll,\
 $BUILD_DIR/bin/websocket-sharp.dll,\
 System.Runtime.Serialization.dll,\
 $BUILD_DIR/bin/${ROOT_NAMESPACE}.dll,\
-$BUILD_DIR/bin/nunit.framework.dll \
+$BUILD_DIR/bin/nunit.framework.dll, \
+$BUILD_DIR/bin/Moq.dll \
 -target:library \
 -out:$BUILD_DIR/bin/${ROOT_NAMESPACE}.Tests.dll \
 -recurse:'src/'${ROOT_NAMESPACE}.Tests'/*.cs' \

--- a/resources/sdk/pureclouddotnet/scripts/compile.sh
+++ b/resources/sdk/pureclouddotnet/scripts/compile.sh
@@ -30,7 +30,7 @@ cp $BUILD_DIR/packages/Newtonsoft.Json.11.0.2/lib/net45/Newtonsoft.Json.dll $BUI
 cp $BUILD_DIR/packages/RestSharp.106.3.1/lib/net452/RestSharp.dll $BUILD_DIR/bin/RestSharp.dll;
 cp $BUILD_DIR/packages/WebSocketSharp.1.0.3-rc11/lib/websocket-sharp.dll $BUILD_DIR/bin/websocket-sharp.dll;
 cp $BUILD_DIR/packages/NUnit.3.10.1/lib/net45/nunit.framework.dll $BUILD_DIR/bin/nunit.framework.dll;
-cp $BUILD_DIR/packages/Moq.4.7.0/lib/net45/Moq.dll $BUILD_DIR/bin/Moq.dll;
+cp $BUILD_DIR/packages/Moq.4.5.3/lib/net45/Moq.dll $BUILD_DIR/bin/Moq.dll;
 
 echo "Compiling SDK..."
 mcs -r:$BUILD_DIR/bin/Newtonsoft.Json.dll,\

--- a/resources/sdk/pureclouddotnet/scripts/compile.sh
+++ b/resources/sdk/pureclouddotnet/scripts/compile.sh
@@ -30,10 +30,7 @@ cp $BUILD_DIR/packages/Newtonsoft.Json.11.0.2/lib/net45/Newtonsoft.Json.dll $BUI
 cp $BUILD_DIR/packages/RestSharp.106.3.1/lib/net452/RestSharp.dll $BUILD_DIR/bin/RestSharp.dll;
 cp $BUILD_DIR/packages/WebSocketSharp.1.0.3-rc11/lib/websocket-sharp.dll $BUILD_DIR/bin/websocket-sharp.dll;
 cp $BUILD_DIR/packages/NUnit.3.10.1/lib/net45/nunit.framework.dll $BUILD_DIR/bin/nunit.framework.dll;
-cp $BUILD_DIR/packages/Moq.4.13.1/lib/net45/Moq.dll $BUILD_DIR/bin/Moq.dll;
-cp $BUILD_DIR/packages/Castle.Core.4.4.0/lib/net45/Castle.Core.dll $BUILD_DIR/bin/Castle.Core.dll;
-cp $BUILD_DIR/packages/System.Threading.Tasks.Extensions.4.5.1/lib/netstandard1.0/System.Threading.Tasks.Extensions.dll $BUILD_DIR/bin/System.Threading.Tasks.Extensions.dll;
-cp $BUILD_DIR/packages/System.Runtime.CompilerServices.Unsafe.4.5.0/lib/netstandard1.0/System.Runtime.CompilerServices.Unsafe.dll $BUILD_DIR/bin/System.Runtime.CompilerServices.Unsafe.dll;
+cp $BUILD_DIR/packages/Moq.4.7.0/lib/net45/Moq.dll $BUILD_DIR/bin/Moq.dll;
 
 echo "Compiling SDK..."
 mcs -r:$BUILD_DIR/bin/Newtonsoft.Json.dll,\
@@ -52,7 +49,7 @@ $BUILD_DIR/bin/RestSharp.dll,\
 $BUILD_DIR/bin/websocket-sharp.dll,\
 System.Runtime.Serialization.dll,\
 $BUILD_DIR/bin/${ROOT_NAMESPACE}.dll,\
-$BUILD_DIR/bin/nunit.framework.dll, \
+$BUILD_DIR/bin/nunit.framework.dll,\
 $BUILD_DIR/bin/Moq.dll \
 -target:library \
 -out:$BUILD_DIR/bin/${ROOT_NAMESPACE}.Tests.dll \

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -101,7 +101,7 @@ namespace {{packageName}}.Client
         /// Gets or sets the RestClient.
         /// </summary>
         /// <value>An instance of the RestClient</value>
-        public RestClient RestClient { get; set; }
+        public IRestClient RestClient { get; set; }
 
         private RetryConfiguration retryConfig;
         private readonly RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
@@ -312,7 +312,7 @@ namespace {{packageName}}.Client
          /// <summary>
         /// Creates a restclient with a base path string input
         /// <returns>Returns a rest client</returns>
-        public RestClient setBasePath(String basePath){
+        public IRestClient setBasePath(String basePath){
             if (String.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");
 
@@ -323,7 +323,7 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Creates a restclient with a PureCloudRegionHost string input
         /// <returns>Returns a rest client</returns>
-        public RestClient setBasePath(PureCloudRegionHosts region){
+        public IRestClient setBasePath(PureCloudRegionHosts region){
          return setBasePath(region.GetDescription());
         }
 
@@ -611,7 +611,7 @@ namespace {{packageName}}.Client
         private long backoffIntervalMs;
         private long retryAfterDefaultMs;
         private int maxRetryTimeSec;
-        private int maxRetriesBeforeBackoff = 0;
+        private int maxRetriesBeforeBackoff = 5;
         private int retryCountBeforeBackOff = 0;
         private long retryAfterMs;
         private Stopwatch stopwatch;
@@ -634,7 +634,7 @@ namespace {{packageName}}.Client
         {
             if (stopwatch.ElapsedMilliseconds < maxRetryTimeSec * 1000L && statusCodes.Contains((int)response.StatusCode))
             {
-                var retryAfterHeader = response.Headers.ToList().FirstOrDefault(y => y.Name.Equals("Retry-After"));
+                var retryAfterHeader = response.Headers.FirstOrDefault(y => y.Name.Equals("Retry-After"));
 
                 if (retryAfterHeader != null && Int32.TryParse(retryAfterHeader.Value.ToString(), out int retryAfterSec)){
                 retryAfterMs =  retryAfterSec * 1000;
@@ -650,7 +650,7 @@ namespace {{packageName}}.Client
                 }
 
                 //If status code is 50x then wait for every 3 Sec and retry until 5 minutes then after wait for every 9 Sec and retry until next 5 minutes afterwards wait for every 27 Sec and retry.
-                return waitBeforeRetry(getWaitTimeExp(Math.Min(3, (stopwatch.ElapsedMilliseconds / backoffIntervalMs) + 1)));
+                return waitBeforeRetry(getWaitTimeExp(Math.Min(3, Math.Floor(stopwatch.ElapsedMilliseconds / backoffIntervalMs * 1.0) + 1)));
 
             }
             stopwatch.Stop();
@@ -670,7 +670,7 @@ namespace {{packageName}}.Client
             return true;
         }
 
-        private long getWaitTimeExp(long bucketCount)
+        private long getWaitTimeExp(double bucketCount)
         {
             return (long)Math.Pow(3, bucketCount) * 1000L;
         }

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -204,19 +204,17 @@ namespace {{packageName}}.Client
             // Set SDK version
             request.AddHeader("purecloud-sdk", "{{packageVersion}}");
 
-            {{^supportsUWP}}
             Retry retry = new Retry(this.RetryConfig);
-            IRestResponse response = null;
-
+            IRestResponse response;
             do{
+            {{^supportsUWP}}
                 response = RestClient.Execute(request);
-               }while(retry.ShouldRetry(response));
-
             {{/supportsUWP}}
             {{#supportsUWP}}
             // Using async method to perform sync call (uwp-only)
-            var response = RestClient.ExecuteTaskAsync(request).Result;
+               response = RestClient.ExecuteTaskAsync(request).Result;
             {{/supportsUWP}}
+            }while(retry.ShouldRetry(response));
             return (Object) response;
         }
         {{#supportsAsync}}
@@ -242,7 +240,13 @@ namespace {{packageName}}.Client
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
-            var response = await RestClient.ExecuteTaskAsync(request);
+
+             Retry retry = new Retry(this.RetryConfig);
+             IRestResponse response;
+            do{
+               response = await RestClient.ExecuteTaskAsync(request);
+               }while(retry.ShouldRetry(response));
+
             return (Object)response;
         }{{/supportsAsync}}
 
@@ -611,7 +615,7 @@ namespace {{packageName}}.Client
         private int maxRetriesBeforeBackoff = 0;
         private int retryCountBeforeBackOff = 0;
         private long retryAfterMs;
-        private Stopwatch stopwatch = null;
+        private Stopwatch stopwatch;
 
         private readonly List<int> statusCodes = new List<int>() { 429, 502, 503, 504 };
 
@@ -619,8 +623,7 @@ namespace {{packageName}}.Client
             this.backoffIntervalMs = retryConfiguration.BackOffIntervalMs;
             this.retryAfterDefaultMs = retryConfiguration.RetryAfterDefaultMs;
             this.maxRetryTimeSec = retryConfiguration.MaxRetryTimeSec;
-            stopwatch = new Stopwatch();
-            stopwatch.Start();
+            stopwatch = Stopwatch.StartNew();
         }
 
         /// <summary>

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -228,9 +228,10 @@ namespace {{packageName}}.Client
 
              Retry retry = new Retry(this.RetryConfig);
              IRestResponse response;
-            do{
-               response = await RestClient.ExecuteTaskAsync(request);
-               }while(retry.ShouldRetry(response));
+            do
+            {
+                response = await RestClient.ExecuteTaskAsync(request);
+            }while(retry.ShouldRetry(response));
 
             return (Object)response;
         }{{/supportsAsync}}

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -38,6 +38,7 @@ namespace {{packageName}}.Client
 
             Configuration = Configuration.Default;
             RestClient = new RestClient("{{basePath}}");
+            RetryConfig = DEFAULT_RETRY_CONFIG;
             AddSerializerSettings();
         }
 
@@ -57,6 +58,7 @@ namespace {{packageName}}.Client
                 Configuration = config;
 
             RestClient = new RestClient("{{basePath}}");
+            RetryConfig = DEFAULT_RETRY_CONFIG;
             AddSerializerSettings();
         }
 
@@ -74,6 +76,7 @@ namespace {{packageName}}.Client
                 throw new ArgumentException("basePath cannot be empty");
 
             RestClient = new RestClient(basePath);
+            RetryConfig = DEFAULT_RETRY_CONFIG;
             Configuration = Configuration.Default;
             AddSerializerSettings();
         }
@@ -104,26 +107,8 @@ namespace {{packageName}}.Client
         public IRestClient RestClient { get; set; }
 
         private RetryConfiguration retryConfig;
-        private readonly RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
-        public RetryConfiguration RetryConfig
-        {
-            get
-            {
-                return retryConfig;
-            }
-
-            set
-            {
-            if (value == null)
-            {
-               retryConfig = DEFAULT_RETRY_CONFIG;
-            }
-           else
-            {
-                retryConfig = value;
-            }
-            }
-        }
+        public RetryConfiguration RetryConfig { get; set; }
+        private static readonly RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
 
         // Creates and sets up a RestRequest prior to a call.
         private RestRequest PrepareRequest(
@@ -205,7 +190,8 @@ namespace {{packageName}}.Client
 
             Retry retry = new Retry(this.RetryConfig);
             IRestResponse response;
-            do{
+            do
+            {
             {{^supportsUWP}}
                 response = RestClient.Execute(request);
             {{/supportsUWP}}
@@ -551,59 +537,58 @@ namespace {{packageName}}.Client
 
     public class RetryConfiguration
     {
-    private long backoffIntervalMs = 300000L;
-    private long retryAfterDefaultMs = 3000L;
-    private int maxRetryTimeSec = 0;
+        private long backoffIntervalMs = 300000L;
+        private long retryAfterDefaultMs = 3000L;
+        private int maxRetryTimeSec = 0;
 
-    public long BackOffIntervalMs
-    {
-        get
+        public long BackOffIntervalMs
         {
-            return backoffIntervalMs;
-        }
-
-        set
-        {
-            if (value < 0)
+            get
             {
-                throw new ArgumentException("backoffInterval should be a positive integer");
+                return backoffIntervalMs;
             }
-            this.backoffIntervalMs = value;
-        }
-    }
 
-    public long RetryAfterDefaultMs
-    {
-        get
-        {
-            return retryAfterDefaultMs;
-        }
-        set
-        {
-            if (value < 0)
+            set
             {
-                throw new ArgumentException("defaultDelay should be a positive integer");
+                if (value < 0)
+                {
+                    throw new ArgumentException("BackOffIntervalMs should be a positive integer");
+                }
+                this.backoffIntervalMs = value;
             }
-            this.retryAfterDefaultMs = value;
         }
-    }
 
-    public int MaxRetryTimeSec
-    {
-        get
+        public long RetryAfterDefaultMs
         {
-            return maxRetryTimeSec;
-        }
-        set
-        {
-
-            if (value < 0)
+            get
             {
-                throw new ArgumentException("maxRetryTime should be a positive integer");
+                return retryAfterDefaultMs;
             }
-            this.maxRetryTimeSec = value;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentException("RetryAfterDefaultMs should be a positive integer");
+                }
+                this.retryAfterDefaultMs = value;
+            }
         }
-    }
+
+        public int MaxRetryTimeSec
+        {
+            get
+            {
+                return maxRetryTimeSec;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentException("MaxRetryTimeSec should be a positive integer");
+                }
+                this.maxRetryTimeSec = value;
+            }
+        }
     }
 
     private class Retry
@@ -618,7 +603,8 @@ namespace {{packageName}}.Client
 
         private readonly List<int> statusCodes = new List<int>() { 429, 502, 503, 504 };
 
-        public Retry(RetryConfiguration retryConfiguration) {
+        public Retry(RetryConfiguration retryConfiguration)
+        {
             this.backoffIntervalMs = retryConfiguration.BackOffIntervalMs;
             this.retryAfterDefaultMs = retryConfiguration.RetryAfterDefaultMs;
             this.maxRetryTimeSec = retryConfiguration.MaxRetryTimeSec;
@@ -636,8 +622,9 @@ namespace {{packageName}}.Client
             {
                 var retryAfterHeader = response.Headers.FirstOrDefault(y => y.Name.Equals("Retry-After"));
 
-                if (retryAfterHeader != null && Int32.TryParse(retryAfterHeader.Value.ToString(), out int retryAfterSec)){
-                retryAfterMs =  retryAfterSec * 1000;
+                if (retryAfterHeader != null && Int32.TryParse(retryAfterHeader.Value.ToString(), out int retryAfterSec))
+                {
+                    retryAfterMs =  retryAfterSec * 1000;
                 }
                 else
                 {

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -104,8 +104,7 @@ namespace {{packageName}}.Client
         public RestClient RestClient { get; set; }
 
         private RetryConfiguration retryConfig;
-       // private const RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
-
+        private readonly RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
         public RetryConfiguration RetryConfig
         {
             get
@@ -117,7 +116,7 @@ namespace {{packageName}}.Client
             {
             if (value == null)
             {
-               retryConfig = new RetryConfiguration();
+               retryConfig = DEFAULT_RETRY_CONFIG;
             }
            else
             {

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Diagnostics;
+using System.Threading;
 using System.IO;
 {{^supportsUWP}}
 using System.Web;
@@ -101,6 +103,29 @@ namespace {{packageName}}.Client
         /// <value>An instance of the RestClient</value>
         public RestClient RestClient { get; set; }
 
+        private RetryConfiguration retryConfig;
+       // private const RetryConfiguration DEFAULT_RETRY_CONFIG = new RetryConfiguration();
+
+        public RetryConfiguration RetryConfig
+        {
+            get
+            {
+                return retryConfig;
+            }
+
+            set
+            {
+            if (value == null)
+            {
+               retryConfig = new RetryConfiguration();
+            }
+           else
+            {
+                retryConfig = value;
+            }
+            }
+        }
+
         // Creates and sets up a RestRequest prior to a call.
         private RestRequest PrepareRequest(
             String path, RestSharp.Method method, List<Tuple<String, String>> queryParams, Object postBody,
@@ -180,7 +205,13 @@ namespace {{packageName}}.Client
             request.AddHeader("purecloud-sdk", "{{packageVersion}}");
 
             {{^supportsUWP}}
-            var response = RestClient.Execute(request);
+            Retry retry = new Retry(this.RetryConfig);
+            IRestResponse response = null;
+
+            do{
+                response = RestClient.Execute(request);
+               }while(retry.ShouldRetry(response));
+
             {{/supportsUWP}}
             {{#supportsUWP}}
             // Using async method to perform sync call (uwp-only)
@@ -514,5 +545,134 @@ namespace {{packageName}}.Client
             return buffer;
         }
         {{/supportsUWP}}
+
+    public class RetryConfiguration
+    {
+    private long backoffIntervalMs = 300000L;
+    private long retryAfterDefaultMs = 3000L;
+    private int maxRetryTimeSec = 0;
+
+    public long BackOffIntervalMs
+    {
+        get
+        {
+            return backoffIntervalMs;
+        }
+
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentException("backoffInterval should be a positive integer");
+            }
+            this.backoffIntervalMs = value;
+        }
+    }
+
+    public long RetryAfterDefaultMs
+    {
+        get
+        {
+            return retryAfterDefaultMs;
+        }
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentException("defaultDelay should be a positive integer");
+            }
+            this.retryAfterDefaultMs = value;
+        }
+    }
+
+    public int MaxRetryTimeSec
+    {
+        get
+        {
+            return maxRetryTimeSec;
+        }
+        set
+        {
+
+            if (value < 0)
+            {
+                throw new ArgumentException("maxRetryTime should be a positive integer");
+            }
+            this.maxRetryTimeSec = value;
+        }
+    }
+    }
+
+    private class Retry
+    {
+        private long backoffIntervalMs;
+        private long retryAfterDefaultMs;
+        private int maxRetryTimeSec;
+        private int maxRetriesBeforeBackoff = 0;
+        private int retryCountBeforeBackOff = 0;
+        private long retryAfterMs;
+        private Stopwatch stopwatch = null;
+
+        private readonly List<int> statusCodes = new List<int>() { 429, 502, 503, 504 };
+
+        public Retry(RetryConfiguration retryConfiguration) {
+            this.backoffIntervalMs = retryConfiguration.BackOffIntervalMs;
+            this.retryAfterDefaultMs = retryConfiguration.RetryAfterDefaultMs;
+            this.maxRetryTimeSec = retryConfiguration.MaxRetryTimeSec;
+            stopwatch = new Stopwatch();
+            stopwatch.Start();
+        }
+
+        /// <summary>
+        /// Check if retryable
+        /// </summary>
+        /// <param name="response">ApiResponse</param>
+        /// <returns>bool</returns>
+        public bool ShouldRetry(IRestResponse response)
+        {
+            if (stopwatch.ElapsedMilliseconds < maxRetryTimeSec * 1000L && statusCodes.Contains((int)response.StatusCode))
+            {
+                var retryAfterHeader = response.Headers.ToList().FirstOrDefault(y => y.Name.Equals("Retry-After"));
+
+                if (retryAfterHeader != null && Int32.TryParse(retryAfterHeader.Value.ToString(), out int retryAfterSec)){
+                retryAfterMs =  retryAfterSec * 1000;
+                }
+                else
+                {
+                    retryAfterMs = retryAfterDefaultMs;
+                }
+                //If status code is 429 then wait until retry-after time and retry. OR If status code is retryable then for the first 5 times: wait until retry-after time and retry.
+                if ((int)response.StatusCode == 429 || retryCountBeforeBackOff++ < maxRetriesBeforeBackoff)
+                {
+                    return waitBeforeRetry(retryAfterMs);
+                }
+
+                //If status code is 50x then wait for every 3 Sec and retry until 5 minutes then after wait for every 9 Sec and retry until next 5 minutes afterwards wait for every 27 Sec and retry.
+                return waitBeforeRetry(getWaitTimeExp(Math.Min(3, (stopwatch.ElapsedMilliseconds / backoffIntervalMs) + 1)));
+
+            }
+            stopwatch.Stop();
+            return false;
+        }
+
+        private bool waitBeforeRetry(long retryAfterMs)
+        {
+            try
+            {
+                Thread.Sleep((int) retryAfterMs);
+            }
+            catch (ThreadInterruptedException)
+            {
+                Thread.CurrentThread.Interrupt();
+            }
+            return true;
+        }
+
+        private long getWaitTimeExp(long bucketCount)
+        {
+            return (long)Math.Pow(3, bucketCount) * 1000L;
+        }
+    }
+
     }
 }

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -628,7 +628,7 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Check if retryable
         /// </summary>
-        /// <param name="response">ApiResponse</param>
+        /// <param name="response">IRestResponse</param>
         /// <returns>bool</returns>
         public bool ShouldRetry(IRestResponse response)
         {

--- a/resources/sdk/pureclouddotnet/templates/Configuration.mustache
+++ b/resources/sdk/pureclouddotnet/templates/Configuration.mustache
@@ -121,6 +121,7 @@ namespace {{packageName}}.Client
 
                 ApiClient = apiClient;
             }
+            ApiClient.RetryConfig = new ApiClient.RetryConfiguration();
         }
 
         private Dictionary<String, String> _defaultHeaderMap = new Dictionary<String, String>();

--- a/resources/sdk/pureclouddotnet/templates/Configuration.mustache
+++ b/resources/sdk/pureclouddotnet/templates/Configuration.mustache
@@ -121,7 +121,6 @@ namespace {{packageName}}.Client
 
                 ApiClient = apiClient;
             }
-            ApiClient.RetryConfig = new ApiClient.RetryConfiguration();
         }
 
         private Dictionary<String, String> _defaultHeaderMap = new Dictionary<String, String>();

--- a/resources/sdk/pureclouddotnet/templates/README.mustache
+++ b/resources/sdk/pureclouddotnet/templates/README.mustache
@@ -150,15 +150,15 @@ To enable automatic retries, provide a RetryConfiguration object with the maximu
 
 Building a `RetryConfiguration` instance:
 ```{"language":"csharp"}
- var retryConfig = new ApiClient.RetryConfiguration
-            {
-                MaxRetryTimeSec = 10
-            };
+var retryConfig = new ApiClient.RetryConfiguration
+{
+  MaxRetryTimeSec = 10
+};
 ```
 
 Setting `RetryConfiguration` instance to `ApiClient`:
  ```{"language":"csharp"}
-        Configuration.Default.ApiClient.RetryConfig = retryConfig;
+Configuration.Default.ApiClient.RetryConfig = retryConfig;
 ```
 Set the `MaxRetryTimeSec` to the number of seconds to process retries before returning an error.
 When the retry time is a a positive integer, the SDK will follow the recommended backoff logic using the provided configuration.

--- a/resources/sdk/pureclouddotnet/templates/README.mustache
+++ b/resources/sdk/pureclouddotnet/templates/README.mustache
@@ -1,7 +1,6 @@
 ---
 title: Platform API Client SDK - .NET
 ---
-
 [![NuGet Badge](https://buildstats.info/nuget/PureCloudPlatform.Client.V2)](https://www.nuget.org/packages/PureCloudPlatform.Client.V2/)
 
 Documentation can be found at [https://developer.mypurecloud.com/api/rest/client-libraries/dotnet/](https://developer.mypurecloud.com/api/rest/client-libraries/dotnet/)
@@ -143,6 +142,27 @@ Once an access token has been obtained from one of the OAuth methods, it must be
 ```{"language":"csharp"}
 PureCloudPlatform.Client.V2.Client.Configuration.Default.AccessToken = "BL4Cb3EQIQFlqIItaj-zf5eIhAiP96zk3333QImd24P99ojbFHtpgUTJdRIkuUYfXMy0afEnZcWnEQ";
 ```
+
+#### Setting the max retry time
+
+By default, the .NET SDK does not automatically retry any failed requests.
+To enable automatic retries, provide a RetryConfiguration object with the maximum number of seconds to retry requests when building the ApiClient instance.
+
+Building a `RetryConfiguration` instance:
+```{"language":"csharp"}
+ var retryConfig = new ApiClient.RetryConfiguration
+            {
+                MaxRetryTimeSec = 10
+            };
+```
+
+Setting `RetryConfiguration` instance to `ApiClient`:
+ ```{"language":"csharp"}
+        Configuration.Default.ApiClient.RetryConfig = retryConfig;
+```
+Set the `MaxRetryTimeSec` to the number of seconds to process retries before returning an error.
+When the retry time is a a positive integer, the SDK will follow the recommended backoff logic using the provided configuration.
+The best practices are documented in the [Rate Limiting](https://developer.mypurecloud.com/api/rest/rate_limits.html) Developer Center article.
 
 #### Invoking the API
 

--- a/resources/sdk/pureclouddotnet/templates/TestProject.mustache
+++ b/resources/sdk/pureclouddotnet/templates/TestProject.mustache
@@ -65,9 +65,9 @@
     </Reference>
     <Reference Include="Moq">
         <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.7.0\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.7.0\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.7.0\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.5.3\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.5.3\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.5.3\lib\Moq.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/resources/sdk/pureclouddotnet/templates/TestProject.mustache
+++ b/resources/sdk/pureclouddotnet/templates/TestProject.mustache
@@ -63,6 +63,12 @@
         <HintPath Condition="Exists('..\..\packages')">..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
         <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Moq">
+        <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.13.1\lib\Moq.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="**\*.cs"/>

--- a/resources/sdk/pureclouddotnet/templates/TestProject.mustache
+++ b/resources/sdk/pureclouddotnet/templates/TestProject.mustache
@@ -64,7 +64,7 @@
         <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
-        <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Moq.4.5.3\lib\Moq.dll</HintPath>
         <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.5.3\lib\Moq.dll</HintPath>
         <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.5.3\lib\Moq.dll</HintPath>
         <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.5.3\lib\Moq.dll</HintPath>

--- a/resources/sdk/pureclouddotnet/templates/TestProject.mustache
+++ b/resources/sdk/pureclouddotnet/templates/TestProject.mustache
@@ -65,9 +65,9 @@
     </Reference>
     <Reference Include="Moq">
         <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.13.1\lib\Moq.dll</HintPath>
-        <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.13.1\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\packages')">..\packages\Moq.4.7.0\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('..\..\packages')">..\..\packages\Moq.4.7.0\lib\Moq.dll</HintPath>
+        <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\Moq.4.7.0\lib\Moq.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
+++ b/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
@@ -3,4 +3,5 @@
   <package id="NUnit" version="2.6.3" targetFramework="{{targetFrameworkNuget}}" />
   <package id="RestSharp" version="105.1.0" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
+  <package id="Moq" version="4.5.3" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
 </packages>

--- a/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
+++ b/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
@@ -3,4 +3,8 @@
   <package id="NUnit" version="2.6.3" targetFramework="{{targetFrameworkNuget}}" />
   <package id="RestSharp" version="105.1.0" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
+  <package id="Moq" version="4.13.1" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
 </packages>

--- a/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
+++ b/resources/sdk/pureclouddotnet/templates/packages_test.config.mustache
@@ -3,8 +3,4 @@
   <package id="NUnit" version="2.6.3" targetFramework="{{targetFrameworkNuget}}" />
   <package id="RestSharp" version="105.1.0" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
-  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
-  <package id="Moq" version="4.13.1" targetFramework="net452" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
 </packages>

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -26,8 +26,6 @@ public class ApiClientTests
     string environment = Environment.GetEnvironmentVariable("PURECLOUD_ENVIRONMENT");
 
     private Stopwatch stopwatch;
-    private static AuthTokenInfo authTokenInfo;
-    private static String accessToken;
     private static String path = "/api/v2/users";
     private static RestSharp.Method method = Method.GET;
     private static Dictionary<String, String> pathParams = new Dictionary<String, String>();
@@ -51,36 +49,37 @@ public class ApiClientTests
             PureCloudRegionHosts regionval = region.GetValueOrDefault();
             Configuration.Default.ApiClient.setBasePath(regionval);
         }
-        Configuration.Default.ApiClient.Configuration = Configuration.Default;
-        authTokenInfo = Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
-        accessToken = authTokenInfo.AccessToken;
+        var accessTokenInfo = Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
+        Configuration.Default.AccessToken = accessTokenInfo.AccessToken;
     }
 
     [Test]
     public void InvokeTestWith_429()
     {
-         var retryConfig = new ApiClient.RetryConfiguration
+        var retryConfig = new ApiClient.RetryConfiguration
         {
             MaxRetryTimeSec = 6,
             RetryAfterDefaultMs = 100
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = GetTestResponse( 429, "3");
+        RestResponse response = GetTestResponse(429, "3");
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 6000 && stopwatch.ElapsedMilliseconds < 6100, "It will wait for every 100 Mills and retry until 6 Seconds");
-          Assert.AreEqual(429, (int)user.StatusCode);
-          stopwatch.Stop();
+        var configuration = new Configuration();
+        var apiClient = new ApiClient(configuration);
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 6000 && stopwatch.ElapsedMilliseconds < 6100, "It will wait for every 100 Mills and retry until 6 Seconds");
+        Assert.AreEqual(429, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
-   [Test]
+    [Test]
     public void InvokeTestWith_429_And_No_MaxRetryTime()
     {
         var retryConfig = new ApiClient.RetryConfiguration
@@ -90,18 +89,19 @@ public class ApiClientTests
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = GetTestResponse( 429, "3");
+        RestResponse response = GetTestResponse(429, "3");
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-         stopwatch = Stopwatch.StartNew();
-         RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 429");
-         Assert.AreEqual(429, (int)user.StatusCode);
-         stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 429");
+        Assert.AreEqual(429, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -119,15 +119,16 @@ public class ApiClientTests
         response.StatusCode = (HttpStatusCode)502;
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-         stopwatch = Stopwatch.StartNew();
-         RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
-         Assert.AreEqual(502, (int)user.StatusCode);
-         stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
+        Assert.AreEqual(502, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -145,12 +146,13 @@ public class ApiClientTests
         response.StatusCode = (HttpStatusCode)503;
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
 
         stopwatch = Stopwatch.StartNew();
-        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
         Assert.AreEqual(503, (int)user.StatusCode);
         stopwatch.Stop();
@@ -170,12 +172,13 @@ public class ApiClientTests
         response.StatusCode = (HttpStatusCode)504;
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
 
         stopwatch = Stopwatch.StartNew();
-        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
         Assert.AreEqual(504, (int)user.StatusCode);
         stopwatch.Stop();
@@ -194,12 +197,13 @@ public class ApiClientTests
         response.StatusCode = (HttpStatusCode)504;
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
 
         stopwatch = Stopwatch.StartNew();
-        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        RestResponse user = (RestResponse)apiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
         Assert.AreEqual(504, (int)user.StatusCode);
         stopwatch.Stop();
@@ -208,47 +212,49 @@ public class ApiClientTests
     [Test]
     public async Task InvokeAsyncTestWith_429()
     {
-         var retryConfig = new ApiClient.RetryConfiguration
+        var retryConfig = new ApiClient.RetryConfiguration
         {
             MaxRetryTimeSec = 5
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = GetTestResponse( 429, "1");
+        RestResponse response = GetTestResponse(429, "1");
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 5000 && stopwatch.ElapsedMilliseconds < 5100, "It will wait for every 1 Sec provided by Retry-After header Sec and retry for 5 Sec");
-          Assert.AreEqual(429, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 5000 && stopwatch.ElapsedMilliseconds < 5100, "It will wait for every 1 Sec provided by Retry-After header Sec and retry for 5 Sec");
+        Assert.AreEqual(429, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
     public async Task InvokeAsyncTestWith_429_And_No_MaxRetryTime()
     {
-         var retryConfig = new ApiClient.RetryConfiguration
+        var retryConfig = new ApiClient.RetryConfiguration
         {
             MaxRetryTimeSec = 0
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = GetTestResponse( 429, "1");
+        RestResponse response = GetTestResponse(429, "1");
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxWaitTime is 0 it will not retry even if status code is 429");
-          Assert.AreEqual(429, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxWaitTime is 0 it will not retry even if status code is 429");
+        Assert.AreEqual(429, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -265,16 +271,17 @@ public class ApiClientTests
         RestResponse response = new RestResponse();
         response.StatusCode = (HttpStatusCode)502;
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
-          Assert.AreEqual(502, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
+        Assert.AreEqual(502, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -291,16 +298,17 @@ public class ApiClientTests
         RestResponse response = new RestResponse();
         response.StatusCode = (HttpStatusCode)503;
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
-          Assert.AreEqual(503, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
+        Assert.AreEqual(503, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -316,16 +324,17 @@ public class ApiClientTests
         RestResponse response = new RestResponse();
         response.StatusCode = (HttpStatusCode)504;
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
-          Assert.AreEqual(504, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
+        Assert.AreEqual(504, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -340,16 +349,17 @@ public class ApiClientTests
         RestResponse response = new RestResponse();
         response.StatusCode = (HttpStatusCode)504;
 
-         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
-        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
-        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+        mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
 
-          stopwatch = Stopwatch.StartNew();
-          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
-          Assert.AreEqual(504, (int)user.StatusCode);
-          stopwatch.Stop();
+        var apiClient = new ApiClient(new Configuration());
+        apiClient.RetryConfig = retryConfig;
+        apiClient.RestClient = mockRestClient.Object;
+
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse)await apiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
+        Assert.AreEqual(504, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     private RestResponse GetTestResponse(int statusCode, String retryAfterHeader)
@@ -359,8 +369,8 @@ public class ApiClientTests
         response.Headers.Add(new Parameter
         {
             Name = "Retry-After",
-                    Value = retryAfterHeader,
-                    Type = ParameterType.HttpHeader
+            Value = retryAfterHeader,
+            Type = ParameterType.HttpHeader
         });
         return response;
     }

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -80,17 +80,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
           stopwatch = Stopwatch.StartNew();
-          var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 6000 && stopwatch.ElapsedMilliseconds < 6100, "It will wait for every 100 Mills and retry until 6 Seconds");
-            Assert.AreEqual(429, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+          RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 6000 && stopwatch.ElapsedMilliseconds < 6100, "It will wait for every 100 Mills and retry until 6 Seconds");
+          Assert.AreEqual(429, (int)user.StatusCode);
+          stopwatch.Stop();
     }
 
    [Test]
@@ -117,17 +111,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
          stopwatch = Stopwatch.StartNew();
-         var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 429");
-            Assert.AreEqual(429, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+         RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 429");
+         Assert.AreEqual(429, (int)user.StatusCode);
+         stopwatch.Stop();
     }
 
     [Test]
@@ -149,17 +137,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
          stopwatch = Stopwatch.StartNew();
-         var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
-            Assert.AreEqual(502, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+         RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
+         Assert.AreEqual(502, (int)user.StatusCode);
+         stopwatch.Stop();
     }
 
     [Test]
@@ -181,17 +163,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
-            stopwatch = Stopwatch.StartNew();
-            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
-            Assert.AreEqual(503, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
+        Assert.AreEqual(503, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -212,17 +188,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
-            stopwatch = Stopwatch.StartNew();
-            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
-            Assert.AreEqual(504, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
+        Assert.AreEqual(504, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     [Test]
@@ -242,17 +212,11 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        try
-        {
-            stopwatch = Stopwatch.StartNew();
-            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
-        }
-        catch (ApiException ex)
-        {
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
-            Assert.AreEqual(504, ex.ErrorCode);
-            stopwatch.Stop();
-        }
+        stopwatch = Stopwatch.StartNew();
+        RestResponse user = (RestResponse) Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
+        Assert.AreEqual(504, (int)user.StatusCode);
+        stopwatch.Stop();
     }
 
     public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -8,6 +8,7 @@ using {{packageName}}.Model;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using RestSharp;
 using System.Linq;
 using Parameter = RestSharp.Parameter;
@@ -25,8 +26,17 @@ public class ApiClientTests
     string environment = Environment.GetEnvironmentVariable("PURECLOUD_ENVIRONMENT");
 
     private Stopwatch stopwatch;
-    private AuthTokenInfo authTokenInfo;
-    private String accessToken;
+    private static AuthTokenInfo authTokenInfo;
+    private static String accessToken;
+    private static String path = "/api/v2/users";
+    private static RestSharp.Method method = Method.GET;
+    private static Dictionary<String, String> pathParams = new Dictionary<String, String>();
+    private static List<Tuple<String, String>> queryParams = new List<Tuple<String, String>>();
+    private static Dictionary<String, String> headerParams = new Dictionary<String, String>();
+    private static Dictionary<String, String> formParams = new Dictionary<String, String>();
+    private static Dictionary<String, FileParameter> fileParams = new Dictionary<String, FileParameter>();
+    private static Object postBody = null;
+    private static String contentType = null;
 
     [OneTimeSetUp]
     public void Init()
@@ -41,6 +51,7 @@ public class ApiClientTests
             PureCloudRegionHosts regionval = region.GetValueOrDefault();
             Configuration.Default.ApiClient.setBasePath(regionval);
         }
+        Configuration.Default.ApiClient.Configuration = Configuration.Default;
         authTokenInfo = Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
         accessToken = authTokenInfo.AccessToken;
     }
@@ -48,7 +59,7 @@ public class ApiClientTests
     [Test]
     public void invokeTestWith_429()
     {
-        var retryConfig = new ApiClient.RetryConfiguration
+         var retryConfig = new ApiClient.RetryConfiguration
         {
             MaxRetryTimeSec = 6,
             RetryAfterDefaultMs = 100
@@ -69,11 +80,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
-            stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+          stopwatch = Stopwatch.StartNew();
+          var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -83,7 +93,7 @@ public class ApiClientTests
         }
     }
 
-    [Test]
+   [Test]
     public void invokeTestWith_429_And_No_MaxRetryTime()
     {
         var retryConfig = new ApiClient.RetryConfiguration
@@ -107,11 +117,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
-            stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+         stopwatch = Stopwatch.StartNew();
+         var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -140,11 +149,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
-            stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+         stopwatch = Stopwatch.StartNew();
+         var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -173,11 +181,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
             stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -205,11 +212,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
             stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -236,11 +242,10 @@ public class ApiClientTests
         {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
         {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
 
-        var usersApi = new UsersApi();
         try
         {
             stopwatch = Stopwatch.StartNew();
-            var me = usersApi.GetUsers();
+            var user = Configuration.Default.ApiClient.CallApi(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
         }
         catch (ApiException ex)
         {
@@ -249,7 +254,6 @@ public class ApiClientTests
             stopwatch.Stop();
         }
     }
-
 
     public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")
     {

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -14,106 +14,269 @@ using Parameter = RestSharp.Parameter;
 using System.Net;
 using Moq;
 
-namespace {{packageName}}.Tests
+namespace {{packageName }}.Tests
 {
 
-    [TestFixture]
-    public class ApiClientTests
+[TestFixture]
+public class ApiClientTests
+{
+    string clientId = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_ID");
+    string clientSecret = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_SECRET");
+    string environment = Environment.GetEnvironmentVariable("PURECLOUD_ENVIRONMENT");
+
+    private Stopwatch stopwatch;
+    private AuthTokenInfo authTokenInfo;
+    private String accessToken;
+
+    [OneTimeSetUp]
+    public void Init()
     {
-       // string clientId = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_ID");
-       // string clientSecret = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_SECRET");
-      //  string environment = Environment.GetEnvironmentVariable("PURECLOUD_ENVIRONMENT");
-
-        string clientId = "4c2bb5c6-c94d-4eec-bff7-d9449ba7b4ff";
-       string clientSecret = "ONogM5GqbML6t-YhDQD8VcmNylDncXiCP9NqY3sX4ZY";
-
-
-    /*    [Test]
-        public void myTestMethod1()
+        PureCloudRegionHosts? region = getRegion(environment);
+        if (region == null)
         {
-            Console.WriteLine("nAuthenticating...");
-
-            AuthenticateApiClient();
-
-            Console.WriteLine("Authentication Success.");
-
-            var usersApi = new UsersApi();
-
-            Console.WriteLine("Calling Users API to DCA");
-
-
-            var mockRestClient = new Mock<IRestClient>();
-            var mockRestResponse = new Mock<IRestResponse>();
-
-            IRestResponse response = new RestResponse();
-            response.StatusCode = (HttpStatusCode)429;
-
-            response.Headers.Add(new Parameter
-            {
-                Name = "Retry-After",
-                Value = 3,
-                Type = ParameterType.HttpHeader
-            });
-
-            mockRestClient
-               .Setup(x => x.Execute(It.IsAny<IRestRequest>()))
-               .Returns(response);
-            var me = usersApi.GetUsers();
-            Console.WriteLine($"Hello, {me}");
-
-
-           // var result = usersApi.GetUsersAsync();
-           // Console.WriteLine(result.Result);
-
-            Console.WriteLine("Got Users from DCA");
-
-        } */
-
-
-        public void AuthenticateApiClient()
-        {
-          //  PureCloudRegionHosts? region = getRegion(environment);
-          //  if (region == null)
-          //  { //Returned in the case of default value
-              //  Configuration.Default.ApiClient.setBasePath("https://api." + environment);
-                {{packageName}}.Client.Configuration.Default.ApiClient.setBasePath("https://api.inindca.com");
-         //   }
-         //   else
-         //   {
-         //       PureCloudRegionHosts regionval = region.GetValueOrDefault();
-         //       {{packageName}}.Client.Configuration.Default.ApiClient.setBasePath(regionval);
-         //   }
-
-            var accessTokenInfo = {{packageName}}.Client.Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
-            {{packageName}}.Client.Configuration.Default.AccessToken = accessTokenInfo.AccessToken;
+            Configuration.Default.ApiClient.setBasePath("https://api.inindca.com");
         }
-
-        public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")
+        else
         {
-            switch (str)
-            {
-                case "mypurecloud.com":
-                    return PureCloudRegionHosts.us_east_1;
-                case "mypurecloud.ie":
-                    return PureCloudRegionHosts.eu_west_1;
-                case "mypurecloud.de":
-                    return PureCloudRegionHosts.eu_central_1;
-                case "mypurecloud.jp":
-                    return PureCloudRegionHosts.ap_northeast_1;
-                case "mypurecloud.com.au":
-                    return PureCloudRegionHosts.ap_southeast_1;
-                case "usw2.pure.cloud":
-                    return PureCloudRegionHosts.us_west_2;
-                case "cac1.pure.cloud":
-                    return PureCloudRegionHosts.ca_central_1;
-                case "apne2.pure.cloud":
-                    return PureCloudRegionHosts.ap_northeast_2;
-                case "euw2.pure.cloud":
-                    return PureCloudRegionHosts.eu_west_2;
-                default:
-                    Console.WriteLine("Value does not exist in enum using default val");
-                    return null;
-            }
+            PureCloudRegionHosts regionval = region.GetValueOrDefault();
+            Configuration.Default.ApiClient.setBasePath(regionval);
+        }
+        authTokenInfo = Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
+        accessToken = authTokenInfo.AccessToken;
+    }
+
+    [Test]
+    public void invokeTestWith_429()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 6,
+            RetryAfterDefaultMs = 100
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)429;
+        response.Headers.Add(new Parameter
+        {
+            Name = "Retry-After",
+            Value = 3,
+            Type = ParameterType.HttpHeader
+        });
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 6000 && stopwatch.ElapsedMilliseconds < 6100, "It will wait for every 100 Mills and retry until 6 Seconds");
+            Assert.AreEqual(429, ex.ErrorCode);
+            stopwatch.Stop();
         }
     }
+
+    [Test]
+    public void invokeTestWith_429_And_No_MaxRetryTime()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 0,
+            RetryAfterDefaultMs = 100
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)429;
+        response.Headers.Add(new Parameter
+        {
+            Name = "Retry-After",
+            Value = 3,
+            Type = ParameterType.HttpHeader
+        });
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 429");
+            Assert.AreEqual(429, ex.ErrorCode);
+            stopwatch.Stop();
+        }
+    }
+
+    [Test]
+    public void invokeTestWith_502()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 13,
+            RetryAfterDefaultMs = 2000,
+            BackOffIntervalMs = 11000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)502;
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
+            Assert.AreEqual(502, ex.ErrorCode);
+            stopwatch.Stop();
+        }
+    }
+
+    [Test]
+    public void invokeTestWith_503()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 40,
+            RetryAfterDefaultMs = 200,
+            BackOffIntervalMs = 3000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)503;
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
+            Assert.AreEqual(503, ex.ErrorCode);
+            stopwatch.Stop();
+        }
+    }
+
+    [Test]
+    public void invokeTestWith_504()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 2,
+            RetryAfterDefaultMs = 1000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)504;
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
+            Assert.AreEqual(504, ex.ErrorCode);
+            stopwatch.Stop();
+        }
+    }
+
+    [Test]
+    public void invokeTestWith_504_No_MaxRetryTime()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 0
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)504;
+
+        mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+        var usersApi = new UsersApi();
+        try
+        {
+            stopwatch = Stopwatch.StartNew();
+            var me = usersApi.GetUsers();
+        }
+        catch (ApiException ex)
+        {
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
+            Assert.AreEqual(504, ex.ErrorCode);
+            stopwatch.Stop();
+        }
+    }
+
+
+    public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")
+    {
+        switch (str)
+        {
+            case "mypurecloud.com":
+                return PureCloudRegionHosts.us_east_1;
+            case "mypurecloud.ie":
+                return PureCloudRegionHosts.eu_west_1;
+            case "mypurecloud.de":
+                return PureCloudRegionHosts.eu_central_1;
+            case "mypurecloud.jp":
+                return PureCloudRegionHosts.ap_northeast_1;
+            case "mypurecloud.com.au":
+                return PureCloudRegionHosts.ap_southeast_1;
+            case "usw2.pure.cloud":
+                return PureCloudRegionHosts.us_west_2;
+            case "cac1.pure.cloud":
+                return PureCloudRegionHosts.ca_central_1;
+            case "apne2.pure.cloud":
+                return PureCloudRegionHosts.ap_northeast_2;
+            case "euw2.pure.cloud":
+                return PureCloudRegionHosts.eu_west_2;
+            default:
+                Console.WriteLine("Value does not exist in enum using default val");
+                return null;
+        }
+    }
+}
 }

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -15,7 +15,7 @@ using Parameter = RestSharp.Parameter;
 using System.Net;
 using Moq;
 
-namespace {{packageName }}.Tests
+namespace {{packageName}}.Tests
 {
 
 [TestFixture]
@@ -67,8 +67,7 @@ public class ApiClientTests
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
 
-        var configuration = new Configuration();
-        var apiClient = new ApiClient(configuration);
+        var apiClient = new ApiClient(new Configuration());
         apiClient.RetryConfig = retryConfig;
         apiClient.RestClient = mockRestClient.Object;
 

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -57,7 +57,7 @@ public class ApiClientTests
     }
 
     [Test]
-    public void invokeTestWith_429()
+    public void InvokeTestWith_429()
     {
          var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -66,14 +66,7 @@ public class ApiClientTests
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = new RestResponse();
-        response.StatusCode = (HttpStatusCode)429;
-        response.Headers.Add(new Parameter
-        {
-            Name = "Retry-After",
-            Value = 3,
-            Type = ParameterType.HttpHeader
-        });
+        RestResponse response = GetTestResponse( 429, "3");
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
         {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
@@ -88,7 +81,7 @@ public class ApiClientTests
     }
 
    [Test]
-    public void invokeTestWith_429_And_No_MaxRetryTime()
+    public void InvokeTestWith_429_And_No_MaxRetryTime()
     {
         var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -97,14 +90,7 @@ public class ApiClientTests
         };
 
         var mockRestClient = new Mock<IRestClient>();
-        RestResponse response = new RestResponse();
-        response.StatusCode = (HttpStatusCode)429;
-        response.Headers.Add(new Parameter
-        {
-            Name = "Retry-After",
-            Value = 3,
-            Type = ParameterType.HttpHeader
-        });
+        RestResponse response = GetTestResponse( 429, "3");
 
         mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(response);
         {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
@@ -119,7 +105,7 @@ public class ApiClientTests
     }
 
     [Test]
-    public void invokeTestWith_502()
+    public void InvokeTestWith_502()
     {
         var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -145,7 +131,7 @@ public class ApiClientTests
     }
 
     [Test]
-    public void invokeTestWith_503()
+    public void InvokeTestWith_503()
     {
         var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -171,7 +157,7 @@ public class ApiClientTests
     }
 
     [Test]
-    public void invokeTestWith_504()
+    public void InvokeTestWith_504()
     {
         var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -196,7 +182,7 @@ public class ApiClientTests
     }
 
     [Test]
-    public void invokeTestWith_504_No_MaxRetryTime()
+    public void InvokeTestWith_504_No_MaxRetryTime()
     {
         var retryConfig = new ApiClient.RetryConfiguration
         {
@@ -217,6 +203,166 @@ public class ApiClientTests
         Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
         Assert.AreEqual(504, (int)user.StatusCode);
         stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_429()
+    {
+         var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 5
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = GetTestResponse( 429, "1");
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 5000 && stopwatch.ElapsedMilliseconds < 5100, "It will wait for every 1 Sec provided by Retry-After header Sec and retry for 5 Sec");
+          Assert.AreEqual(429, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_429_And_No_MaxRetryTime()
+    {
+         var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 0
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = GetTestResponse( 429, "1");
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxWaitTime is 0 it will not retry even if status code is 429");
+          Assert.AreEqual(429, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_502()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 13,
+            RetryAfterDefaultMs = 2000,
+            BackOffIntervalMs = 11000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)502;
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 13000 && stopwatch.ElapsedMilliseconds < 13100, "It will wait for every 2 Sec and retry for 5 times then it will backoff for 3 sec and retry then it exits.");
+          Assert.AreEqual(502, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_503()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 40,
+            RetryAfterDefaultMs = 200,
+            BackOffIntervalMs = 3000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)503;
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 40000 && stopwatch.ElapsedMilliseconds < 40100, "It will wait for every 200 Mills and retry for 5 times then it will backoff for 3 Sec once, 9 Sec once and 27 Sec before retrying");
+          Assert.AreEqual(503, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_504()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 2,
+            RetryAfterDefaultMs = 1000
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)504;
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 2000 && stopwatch.ElapsedMilliseconds < 2100, "It will wait for every 1 sec and retry for 2 times");
+          Assert.AreEqual(504, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    [Test]
+    public async Task InvokeAsyncTestWith_504_And_No_MaxRetryTime()
+    {
+        var retryConfig = new ApiClient.RetryConfiguration
+        {
+            MaxRetryTimeSec = 0
+        };
+
+        var mockRestClient = new Mock<IRestClient>();
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)504;
+
+         mockRestClient.Setup(x => x.ExecuteTaskAsync(It.IsAny<RestRequest>())).Returns(Task.FromResult<IRestResponse>(response));
+        {{packageName}}.Client.Configuration.Default.AccessToken = accessToken;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RetryConfig = retryConfig;
+        {{packageName}}.Client.Configuration.Default.ApiClient.RestClient = mockRestClient.Object;
+
+          stopwatch = Stopwatch.StartNew();
+          RestResponse user = (RestResponse) await Configuration.Default.ApiClient.CallApiAsync(path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, contentType);
+          Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 0 && stopwatch.ElapsedMilliseconds < 100, "Since maxRetryTime is not provided it will not retry even if the status code is 504");
+          Assert.AreEqual(504, (int)user.StatusCode);
+          stopwatch.Stop();
+    }
+
+    private RestResponse GetTestResponse(int statusCode, String retryAfterHeader)
+    {
+        RestResponse response = new RestResponse();
+        response.StatusCode = (HttpStatusCode)statusCode;
+        response.Headers.Add(new Parameter
+        {
+            Name = "Retry-After",
+                    Value = retryAfterHeader,
+                    Type = ParameterType.HttpHeader
+        });
+        return response;
     }
 
     public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")

--- a/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-ApiClientTests.mustache
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+using System;
+using {{packageName}}.Api;
+using {{packageName}}.Client;
+using {{packageName}}.Extensions;
+using {{packageName}}.Extensions.Notifications;
+using {{packageName}}.Model;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using RestSharp;
+using System.Linq;
+using Parameter = RestSharp.Parameter;
+using System.Net;
+using Moq;
+
+namespace {{packageName}}.Tests
+{
+
+    [TestFixture]
+    public class ApiClientTests
+    {
+       // string clientId = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_ID");
+       // string clientSecret = Environment.GetEnvironmentVariable("PURECLOUD_CLIENT_SECRET");
+      //  string environment = Environment.GetEnvironmentVariable("PURECLOUD_ENVIRONMENT");
+
+        string clientId = "4c2bb5c6-c94d-4eec-bff7-d9449ba7b4ff";
+       string clientSecret = "ONogM5GqbML6t-YhDQD8VcmNylDncXiCP9NqY3sX4ZY";
+
+
+    /*    [Test]
+        public void myTestMethod1()
+        {
+            Console.WriteLine("nAuthenticating...");
+
+            AuthenticateApiClient();
+
+            Console.WriteLine("Authentication Success.");
+
+            var usersApi = new UsersApi();
+
+            Console.WriteLine("Calling Users API to DCA");
+
+
+            var mockRestClient = new Mock<IRestClient>();
+            var mockRestResponse = new Mock<IRestResponse>();
+
+            IRestResponse response = new RestResponse();
+            response.StatusCode = (HttpStatusCode)429;
+
+            response.Headers.Add(new Parameter
+            {
+                Name = "Retry-After",
+                Value = 3,
+                Type = ParameterType.HttpHeader
+            });
+
+            mockRestClient
+               .Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+               .Returns(response);
+            var me = usersApi.GetUsers();
+            Console.WriteLine($"Hello, {me}");
+
+
+           // var result = usersApi.GetUsersAsync();
+           // Console.WriteLine(result.Result);
+
+            Console.WriteLine("Got Users from DCA");
+
+        } */
+
+
+        public void AuthenticateApiClient()
+        {
+          //  PureCloudRegionHosts? region = getRegion(environment);
+          //  if (region == null)
+          //  { //Returned in the case of default value
+              //  Configuration.Default.ApiClient.setBasePath("https://api." + environment);
+                {{packageName}}.Client.Configuration.Default.ApiClient.setBasePath("https://api.inindca.com");
+         //   }
+         //   else
+         //   {
+         //       PureCloudRegionHosts regionval = region.GetValueOrDefault();
+         //       {{packageName}}.Client.Configuration.Default.ApiClient.setBasePath(regionval);
+         //   }
+
+            var accessTokenInfo = {{packageName}}.Client.Configuration.Default.ApiClient.PostToken(clientId, clientSecret);
+            {{packageName}}.Client.Configuration.Default.AccessToken = accessTokenInfo.AccessToken;
+        }
+
+        public Nullable<PureCloudRegionHosts> getRegion(String str = "http://api.mypurecloud.com")
+        {
+            switch (str)
+            {
+                case "mypurecloud.com":
+                    return PureCloudRegionHosts.us_east_1;
+                case "mypurecloud.ie":
+                    return PureCloudRegionHosts.eu_west_1;
+                case "mypurecloud.de":
+                    return PureCloudRegionHosts.eu_central_1;
+                case "mypurecloud.jp":
+                    return PureCloudRegionHosts.ap_northeast_1;
+                case "mypurecloud.com.au":
+                    return PureCloudRegionHosts.ap_southeast_1;
+                case "usw2.pure.cloud":
+                    return PureCloudRegionHosts.us_west_2;
+                case "cac1.pure.cloud":
+                    return PureCloudRegionHosts.ca_central_1;
+                case "apne2.pure.cloud":
+                    return PureCloudRegionHosts.ap_northeast_2;
+                case "euw2.pure.cloud":
+                    return PureCloudRegionHosts.eu_west_2;
+                default:
+                    Console.WriteLine("Value does not exist in enum using default val");
+                    return null;
+            }
+        }
+    }
+}

--- a/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
@@ -52,12 +52,6 @@
       <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
     </Reference>

--- a/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
@@ -48,17 +48,31 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Castle.Core">
+      <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SdkTests.cs" />
+    <Compile Include="ApiClientTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\{{packageName}}\{{packageName}}.csproj">
-      <Project>{65ee3497-a7d4-4651-abf6-0cf35cbec930}</Project>
+      <Project>{4937181E-4E38-4809-BF8B-2483F3444CEB}</Project>
       <Name>{{packageName}}</Name>
     </ProjectReference>
   </ItemGroup>

--- a/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
@@ -48,9 +48,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Castle.Core">
-      <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
@@ -66,7 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\{{packageName}}\{{packageName}}.csproj">
-      <Project>{4937181E-4E38-4809-BF8B-2483F3444CEB}</Project>
+      <Project>{65ee3497-a7d4-4651-abf6-0cf35cbec930}</Project>
       <Name>{{packageName}}</Name>
     </ProjectReference>
   </ItemGroup>

--- a/resources/sdk/pureclouddotnet/templates/test-packages.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-packages.mustache
@@ -3,6 +3,5 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NUnit" version="3.10.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net452" />
-  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
-  <package id="Moq" version="4.7.0" targetFramework="net452" />
+  <package id="Moq" version="4.5.3" targetFramework="net452" />
 </packages>

--- a/resources/sdk/pureclouddotnet/templates/test-packages.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-packages.mustache
@@ -3,4 +3,8 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NUnit" version="3.10.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
+  <package id="Moq" version="4.13.1" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
 </packages>

--- a/resources/sdk/pureclouddotnet/templates/test-packages.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-packages.mustache
@@ -4,7 +4,5 @@
   <package id="NUnit" version="3.10.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net452" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
-  <package id="Moq" version="4.13.1" targetFramework="net452" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
+  <package id="Moq" version="4.7.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
```
Running tests...
NUnit Console Runner 3.8.0 
Copyright (c) 2018 Charlie Poole, Rob Prouse

Runtime Environment
   OS Version: MacOSX 18.7.0.0 
  CLR Version: 4.0.30319.42000

Test Files
    /Users/deerghayu/IdeaProjects/DEER/platform-client-sdk-common/output/pureclouddotnet/build/bin/PureCloudPlatform.Client.V2.Tests.dll

=> PureCloudPlatform.Client.V2.Tests.SdkTests.TraceBasicInformation
PURECLOUD_ENVIRONMENT=mypurecloud.com
PURECLOUD_CLIENT_ID=7de3af06-c0b3-4f9b-af45-72f4a14037cc
userEmail=69a4f576-c084-4428-9817-3519092b928b@mypurecloud.com
=> PureCloudPlatform.Client.V2.Tests.SdkTests.CreateUser
Created user with ID f23c3595-b1ff-47cd-be06-3bcccf54358f

Run Settings
    DisposeRunners: True
    WorkDirectory: /Users/deerghayu/IdeaProjects/DEER/platform-client-sdk-common/output/pureclouddotnet/build
    ImageRuntimeVersion: 4.0.30319
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 12

Test Run Summary
  Overall result: Passed
  Test Count: 20, Passed: 20, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 0
  Start time: 2020-04-01 02:08:40Z
    End time: 2020-04-01 02:10:45Z
    Duration: 124.809 seconds

Results (nunit3) saved as TestResult.xml