### PR TITLE
API-5248 JS SDK not encoding redirect uri correctly

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -283,7 +283,7 @@ class ApiClient {
 					this._debugTrace(error);
 					var query = {
 						client_id: encodeURIComponent(this.clientId),
-						redirect_uri: encodeURI(this.redirectUri),
+						redirect_uri: encodeURIComponent(this.redirectUri),
 						response_type: 'token'
 					};
 					if (opts.state) query.state = encodeURIComponent(opts.state);


### PR DESCRIPTION
The JS SDK was using "encodeURI" for the redirect URI, this was causing redirect URIs with more than one parameter to be malformed.
Solution was to change "encodeURI" to "encodeURIComponent"