### PR TITLE
Adding a better workaround for an issue with the model file WfmAgentScheduleUpdateTopicWfmFullDayTimeOffMarker.kt

### DIFF
--- a/resources/sdk/purecloudkotlin/scripts/compile.sh
+++ b/resources/sdk/purecloudkotlin/scripts/compile.sh
@@ -39,7 +39,18 @@ export PATH=$PATH:/usr/local/maven/bin
 cd $BUILD_DIR
 
 find . -name "DivsPermittedEntityListing.kt" -exec sed -i '' s/'override var allDivsPermitted'/'var allDivsPermitted'/g {} \;
-find . -name "WfmAgentScheduleUpdateTopicWfmFullDayTimeOffMarker.kt" -exec sed -i '' -e s/'fun paid1'/'fun paid'/g -e s/'    paid1: '/'    paid: '/g {} \;
+# Kotlin generates JVM bytecode for getters + setters of public properties, this causes a clash with another method named "isPaid" in this class
+# The solution here makes the property private and implements our own getter + setter
+find . -name "WfmAgentScheduleUpdateTopicWfmFullDayTimeOffMarker.kt" -exec sed -i '' \
+			-e s/'@get:ApiModelProperty(example = "null", value = "isPaid")'/'@ApiModelProperty(example = "null", value = "")'/g \
+			-e s/'@get:JsonProperty("isPaid")'/'@JsonProperty("isPaid")'/g \
+			-e $'s/var isPaid: Boolean? = null/private var isPaid: Boolean? = null \
+											\\\tfun getIsPaid(): Boolean? { \
+											\\\t\\\treturn isPaid \
+											\\\t} \
+											\\\tfun setIsPaid(isPaid: Boolean?) { \
+											\\\t\\\tthis.isPaid = isPaid \
+											\\\t}/g' {} \;
 
 # Build
 mvn $MAVEN_SETTINGS_FILE $BUILD_MODE $DPGP_PASSPHRASE


### PR DESCRIPTION
Kotlin generates JVM bytecode for getters + setters of public properties, this causes a clash with another method named "isPaid" in this class
This solution makes the property private and implements our own getter + setter