### PR TITLE
Increase retry config parameters in paging logic so avoid rate-limits

### DIFF
--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -101,7 +101,10 @@ func (c *commandService) List(uri string) (string, error) {
 		for x := 2; x <= firstPage.PageCount; x++ {
 			pagedURI = updatePageNumber(pagedURI, x)
 			retryFunc := retry.Retry(pagedURI, restClient.Get)
-			data, err = retryFunc(nil)
+			data, err = retryFunc(&retry.RetryConfiguration{
+				MaxRetryTimeSec: 20,
+				MaxRetriesBeforeQuitting: 10,
+			})
 			if err != nil {
 				return "", err
 			}

--- a/resources/sdk/clisdkclient/templates/README.mustache
+++ b/resources/sdk/clisdkclient/templates/README.mustache
@@ -11,6 +11,8 @@ This CLI focuses mainly on exposing the following operations:
 - **update** - Update a Genesys Cloud object via data passed in via stdin or via file.
 - **delete** - Delete a Genesys Cloud object via data passed in via stdin or via file.
 
+**Note** Most operations exposed by the `list` command and some operations exposed by the `get` command support the `pageSize` parameter. It's important to set this to an appropriate value if a large amount of resources are being listed to reduce load on the API and reduce wait times.
+
 The following objects are currently supported by the CLI:
 - campaigns
 - divisions


### PR DESCRIPTION
- Increase retry config parameters in paging logic so avoid rate-limits
- Add note in README to include pageSize param in list commands to reduce API load