### PR TITLE
Add 'module' field to package.json

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/package.mustache
+++ b/resources/sdk/purecloudjavascript/templates/package.mustache
@@ -5,6 +5,7 @@
   "license": "{{{projectLicenseName}}}",{{/projectLicenseName}}
   "main": "dist/node/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.js",
   "types": "index.d.ts",
+  "module": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "jsnext:main": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "browser": "dist/web-cjs/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.min.js",
   "files": [


### PR DESCRIPTION
The 'module' field is a newer alternative to 'jsnext:main', and helps allow the package to be consumed as raw ES Modules.  

We ran into this issue when trying to consume this package through Snowpack, which is a non-bundling build tool for JS development, and prefers to consume dependencies as ES Modules, rather than in AMD or CJS formats.