### PR TITLE
Devengage 413 module entry point

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/=true

--- a/resources/sdk/purecloudjavascript-guest/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/README.mustache
@@ -58,7 +58,7 @@ For direct use in a browser script:
 
 The node package's [package.json](https://github.com/MyPureCloud/purecloud-guest-chat-client-javascript/blob/master/build/package.json) file contains the following entry points for use with various packaging systems:
 
-* **jsnext:main**
+* **jsnext:main** and **module**
   * Entry point: src/{{projectName}}/index.js
   * The main ES6 class in the source code
 * **main**

--- a/resources/sdk/purecloudjavascript-guest/templates/package.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/package.mustache
@@ -5,6 +5,7 @@
   "license": "{{{projectLicenseName}}}",{{/projectLicenseName}}
   "main": "dist/node/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.js",
   "types": "index.d.ts",
+  "module": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "jsnext:main": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "browser": "dist/web-cjs/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.min.js",
   "files": [

--- a/resources/sdk/purecloudjavascript/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript/templates/README.mustache
@@ -54,7 +54,7 @@ For direct use in a browser script:
 
 The node package's [package.json](https://github.com/MyPureCloud/platform-client-sdk-javascript/blob/master/build/package.json) file contains the following entry points for use with various packaging systems:
 
-* **jsnext:main**
+* **jsnext:main** and **module**
 	* Entry point: src/{{projectName}}/index.js
 	* The main ES6 class in the source code
 * **main**

--- a/resources/sdk/purecloudjavascript/templates/package.mustache
+++ b/resources/sdk/purecloudjavascript/templates/package.mustache
@@ -5,6 +5,7 @@
   "license": "{{{projectLicenseName}}}",{{/projectLicenseName}}
   "main": "dist/node/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.js",
   "types": "index.d.ts",
+  "module": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "jsnext:main": "src/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}/index.js",
   "browser": "dist/web-cjs/{{#invokerPackage}}{{invokerPackage}}{{/invokerPackage}}.min.js",
   "files": [


### PR DESCRIPTION
This adds a new entry `module` point to the JavaScript and JavaScript Guest SDKs that's now preferred over `jsnext:main`.

Changes initially added by @Retsam