### PR TITLE
Use rollup replace plugin to remove some node logic from the web bundle

### DIFF
--- a/resources/sdk/purecloudjavascript-guest/templates/rollup-cjs-for-browserify.config.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/rollup-cjs-for-browserify.config.mustache
@@ -44,6 +44,20 @@ export default {
 					test: 'if (global.GENTLY) require = GENTLY.hijack(require);', 
 					// string or function to replaced with
 					replace: '',
+				},
+				/*
+				  Replace some browser feature detection logic with a literal value
+				  This causes this code to be compiled out of the build via dead code-elimination:
+				  ```
+				  if (typeof window === 'undefined' &&
+				      typeof require === 'function' &&
+				      require('fs')) {}
+				  ```
+				  This eliminates some pontential down-stream bundling complications with `require('fs')`
+				*/
+				{
+					test: "typeof window === 'undefined'",
+					replace: "false",
 				}
 			]
 		}),

--- a/resources/sdk/purecloudjavascript/templates/rollup-cjs-for-browserify.config.mustache
+++ b/resources/sdk/purecloudjavascript/templates/rollup-cjs-for-browserify.config.mustache
@@ -44,6 +44,20 @@ export default {
 					test: 'if (global.GENTLY) require = GENTLY.hijack(require);', 
 					// string or function to replaced with
 					replace: '',
+				},
+				/*
+				  Replace some browser feature detection logic with a literal value
+				  This causes this code to be compiled out of the build via dead code-elimination:
+				  ```
+				  if (typeof window === 'undefined' &&
+				      typeof require === 'function' &&
+				      require('fs')) {}
+				  ```
+				  This eliminates some pontential down-stream bundling complications with `require('fs')`
+				*/
+				{
+					test: "typeof window === 'undefined'",
+					replace: "false",
 				}
 			]
 		}),


### PR DESCRIPTION
We had some downstream pain consuming this library in a bundled web app, due to this code:

```js
if (typeof window === 'undefined' &&
        typeof require === 'function' &&
        require('fs') &&
        param instanceof require('fs').ReadStream) {
    return true;
}
```

Although the `require('fs')` doesn't actually get run, webpack was convinced that 'fs' was a dependency when trying to build, due to the require('fs') import.

We're actually using webpack indirectly through snowpack, (I have no little doubt our non-conventional setup is part of the issue), and we can work around this on our end, but it's nice if the web bundle just doesn't contain that code at all, so this uses a rollup replacement to remove it.

I confirmed that with this addition to the rollup config, the entire block listed above is removed from `web-cjs/bundle.js`