### PR TITLE
Add basic externalcontacts support to Genesys Cloud CLI

### DIFF
--- a/resources/sdk/clisdkclient/extensions/cmd/externalcontacts/externalcontacts.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/externalcontacts/externalcontacts.go
@@ -1,0 +1,15 @@
+package externalcontacts
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var externalcontactsCmd = &cobra.Command{
+	Use:   "externalcontacts",
+	Short: "Manages Genesys Cloud external contacts",
+	Long:  `Manages Genesys Cloud external contacts`,
+}
+
+func Cmdexternalcontacts() *cobra.Command {
+	return externalcontactsCmd
+}

--- a/resources/sdk/clisdkclient/resources/resourceDefinitions.json
+++ b/resources/sdk/clisdkclient/resources/resourceDefinitions.json
@@ -222,7 +222,7 @@
 			"operationId": "search"
 		}
 	},
-	"/api/v2/externalcontacts/contacts/{contactId}" : {
+	"/api/v2/externalcontacts/contacts/{contactId}": {
 		"tag": "contacts",
 		"supercommand": "externalcontacts",
 		"get": {},
@@ -237,21 +237,21 @@
 			"operationId": "search"
 		}
 	},
-	"/api/v2/externalcontacts/organizations/{externalOrganizationId}" : {
+	"/api/v2/externalcontacts/organizations/{externalOrganizationId}": {
 		"tag": "organizations",
 		"supercommand": "externalcontacts",
 		"get": {},
 		"put": {},
 		"delete": {}
 	},
-	"/api/v2/externalcontacts/scan/contacts" : {
+	"/api/v2/externalcontacts/scan/contacts": {
 		"tag": "contacts",
 		"supercommand": "externalcontacts",
 		"get": {
 			"operationId": "scan"
 		}
 	},
-	"/api/v2/externalcontacts/scan/organizations" : {
+	"/api/v2/externalcontacts/scan/organizations": {
 		"tag": "organizations",
 		"supercommand": "externalcontacts",
 		"get": {

--- a/resources/sdk/clisdkclient/resources/resourceDefinitions.json
+++ b/resources/sdk/clisdkclient/resources/resourceDefinitions.json
@@ -243,5 +243,19 @@
 		"get": {},
 		"put": {},
 		"delete": {}
+	},
+	"/api/v2/externalcontacts/scan/contacts" : {
+		"tag": "contacts",
+		"supercommand": "externalcontacts",
+		"get": {
+			"operationId": "scan"
+		}
+	},
+	"/api/v2/externalcontacts/scan/organizations" : {
+		"tag": "organizations",
+		"supercommand": "externalcontacts",
+		"get": {
+			"operationId": "scan"
+		}
 	}
 }

--- a/resources/sdk/clisdkclient/resources/resourceDefinitions.json
+++ b/resources/sdk/clisdkclient/resources/resourceDefinitions.json
@@ -208,5 +208,26 @@
 		"get": {
 			"operationId": "results"
 		}
+	},
+	"/api/v2/groups/search": {
+		"tag": "search",
+		"supercommand": "groups",
+		"doNotPluralize": true
+	},
+	"/api/v2/externalcontacts/contacts": {
+		"tag": "contacts",
+		"supercommand": "externalcontacts",
+		"post": {},
+		"get": {
+			"operationId": "search"
+		}
+	},
+	"/api/v2/externalcontacts/organizations": {
+		"tag": "organizations",
+		"supercommand": "externalcontacts",
+		"post": {},
+		"get": {
+			"operationId": "search"
+		}
 	}
 }

--- a/resources/sdk/clisdkclient/resources/resourceDefinitions.json
+++ b/resources/sdk/clisdkclient/resources/resourceDefinitions.json
@@ -222,6 +222,13 @@
 			"operationId": "search"
 		}
 	},
+	"/api/v2/externalcontacts/contacts/{contactId}" : {
+		"tag": "contacts",
+		"supercommand": "externalcontacts",
+		"get": {},
+		"put": {},
+		"delete": {}
+	},
 	"/api/v2/externalcontacts/organizations": {
 		"tag": "organizations",
 		"supercommand": "externalcontacts",
@@ -229,5 +236,12 @@
 		"get": {
 			"operationId": "search"
 		}
+	},
+	"/api/v2/externalcontacts/organizations/{externalOrganizationId}" : {
+		"tag": "organizations",
+		"supercommand": "externalcontacts",
+		"get": {},
+		"put": {},
+		"delete": {}
 	}
 }


### PR DESCRIPTION
Add basic support for External Contacts to the Genesys Cloud CLI.

This PR add support single-entity CRUD, scan, and search operations for Contacts and External Organizations.

Notes and relationships will be added later due to some complication.

@ronanwatkins @carnellj @timsmithgenesys 