### PR TITLE
Applying solution to duplicate command names for the CLI.

### DIFF
--- a/resources/sdk/clisdkclient/config.json
+++ b/resources/sdk/clisdkclient/config.json
@@ -1,6 +1,7 @@
 {
   "name": "GO CLI SDK",
   "envVars": {
+  	"EXCLUDE_NOTIFICATIONS": true
   },
   "settings": {
     "sdkRepo": {
@@ -54,7 +55,8 @@
             {
               "$ref": "#/settings/swagger/newSwaggerPath"
             },
-            "${SDK_TEMP}/newSwagger.json"
+            "${SDK_TEMP}/newSwagger.json",
+            "${SDK_TEMP}/duplicateMappings.json"
           ],
           "failOnError": true
         }
@@ -70,7 +72,8 @@
           "args": [
             "${SDK_REPO}/build/gc/cmd/root.go",
             "${SDK_REPO}/build/gc/services/commandservice.go",
-            "${SDK_REPO}/build/gc/utils/general.go"
+            "${SDK_REPO}/build/gc/utils/general.go",
+            "${SDK_TEMP}/duplicateMappings.json"
           ],
           "failOnError": true
         }

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -67,10 +67,7 @@ func GetFlag(flags *pflag.FlagSet, paramType string, name string) string {
 }
 
 func FormatUsageDescription(message string) string {
-	if strings.Contains(message, "user") {
-		message = strings.ReplaceAll(message, "role", "")
-		message = strings.ReplaceAll(message, "queue", "")
-	}
+	message = strings.Split(message, "_")[0]
 
 	notPluralCommands := make([]string, 0)
 	{{=it.notPluralCommands}}

--- a/resources/sdk/clisdkclient/resources/resourceDefinitions.json
+++ b/resources/sdk/clisdkclient/resources/resourceDefinitions.json
@@ -23,21 +23,21 @@
 		"put": {}
 	},
 	"/api/v2/authorization/roles/{roleId}/users": {
-		"tag": "roleuser",
+		"tag": "users",
 		"supercommand": "roles",
 		"get": {
 			"operationId": "get"
 		}
 	},
 	"/api/v2/authorization/roles/{roleId}/users/add": {
-		"tag": "roleuser",
+		"tag": "users",
 		"supercommand": "roles",
 		"put": {
 			"operationId": "add"
 		}
 	},
 	"/api/v2/authorization/roles/{roleId}/users/remove": {
-		"tag": "roleuser",
+		"tag": "users",
 		"supercommand": "roles",
 		"put": {
 			"operationId": "delete"
@@ -111,7 +111,7 @@
 		}
 	},
 	"/api/v2/routing/queues/{queueId}/users": {
-		"tag": "queueuser",
+		"tag": "users",
 		"supercommand": "queues",
 		"entityListing": true,
 		"get": {
@@ -125,7 +125,7 @@
 		}
 	},
 	"/api/v2/routing/queues/{queueId}/users/{memberId}": {
-		"tag": "queueuser",
+		"tag": "users",
 		"supercommand": "queues",
 		"delete": {},
 		"patch": {}


### PR DESCRIPTION
Duplicates will now be postfixed with their supercommand. For example, roles and queues both have users commands, they will become users_queues and users_roles respectively.
Logic has been added to FormatUsageDescription in general.go to format the command name correctly.