### PR TITLE
Fix Go SDK error body serialization

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiresponse.mustache
+++ b/resources/sdk/purecloudgo/templates/apiresponse.mustache
@@ -40,7 +40,8 @@ func (r *APIResponse) SetError(err *APIError) {
 type APIError struct {
 	Status            int                    `json:"status,omitempty"`
 	Message           string                 `json:"message,omitempty"`
-	MessageWithParams map[string]interface{} `json:"messageWithParams,omitempty"`
+	MessageWithParams string                 `json:"messageWithParams,omitempty"`
+	MessageParams     map[string]interface{} `json:"messageParams,omitempty"`
 	Code              string                 `json:"code,omitempty"`
 	ContextID         string                 `json:"contextId,omitempty"`
 	Details           []string               `json:"details,omitempty"`


### PR DESCRIPTION
When the public API returns a 400 with an error response body, the Go SDK is throwing this error: `json: cannot unmarshal string into Go struct field APIError.messageWithParams of type map[string]interface {}`

This is because the `messageWithParams` attribute is actually a string. The `messageParams` attribute is what contains the map.