### PR TITLE
Prevent unmarshal of empty responses

### DIFF
--- a/resources/sdk/purecloudgo/templates/api.mustache
+++ b/resources/sdk/purecloudgo/templates/api.mustache
@@ -142,7 +142,7 @@ func (a {{classname}}) {{nickname}}({{#allParams}}{{paramName}} {{{dataType}}}{{
 		// Nothing special to do here, but do avoid processing the response
 	} else if err == nil && response.Error != nil {
 		err = errors.New(response.ErrorMessage)
-	}{{#returnType}} else {
+	}{{#returnType}} else if len(response.RawBody) > 0 {
 		err = json.Unmarshal([]byte(response.RawBody), &successPayload)
 	}{{/returnType}}
 	return {{#returnType}}successPayload, {{/returnType}}response, err


### PR DESCRIPTION
Some APIs such as PostRoutingQueueMembers return an empty response on success, and attempting to unmarshal an empty body causes json.Unmarshal to return an error when there should not be one.