### PR TITLE
Remove default header trace in Go SDK

### DIFF
--- a/resources/sdk/purecloudgo/templates/api.mustache
+++ b/resources/sdk/purecloudgo/templates/api.mustache
@@ -142,7 +142,7 @@ func (a {{classname}}) {{nickname}}({{#allParams}}{{paramName}} {{{dataType}}}{{
 		// Nothing special to do here, but do avoid processing the response
 	} else if err == nil && response.Error != nil {
 		err = errors.New(response.ErrorMessage)
-	}{{#returnType}} else {
+	}{{#returnType}} else if len(response.RawBody) > 0 {
 		err = json.Unmarshal([]byte(response.RawBody), &successPayload)
 	}{{/returnType}}
 	return {{#returnType}}successPayload, {{/returnType}}response, err

--- a/resources/sdk/purecloudgo/templates/api.mustache
+++ b/resources/sdk/purecloudgo/templates/api.mustache
@@ -142,7 +142,7 @@ func (a {{classname}}) {{nickname}}({{#allParams}}{{paramName}} {{{dataType}}}{{
 		// Nothing special to do here, but do avoid processing the response
 	} else if err == nil && response.Error != nil {
 		err = errors.New(response.ErrorMessage)
-	}{{#returnType}} else if len(response.RawBody) > 0 {
+	}{{#returnType}} else {
 		err = json.Unmarshal([]byte(response.RawBody), &successPayload)
 	}{{/returnType}}
 	return {{#returnType}}successPayload, {{/returnType}}response, err

--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -93,7 +93,6 @@ func (c *APIClient) CallAPI(path string, method string,
 	// Set default headers
 	if c.configuration.DefaultHeader != nil {
 		for k, v := range c.configuration.DefaultHeader {
-			fmt.Printf("  %v=%v", k, v)
 			request.Header.Set(k, v)
 		}
 	}


### PR DESCRIPTION
Prevent always tracing default headers as this spams logs when one is added. If needed, they will be traced on line 133 along with the full Request when the debug setting is enabled.