### PR TITLE
DEVENGAGE-490-responsemgt-fail-without-libraryId

### DIFF
--- a/resources/sdk/clisdkclient/templates/api.mustache
+++ b/resources/sdk/clisdkclient/templates/api.mustache
@@ -30,6 +30,7 @@ func Cmd{{classVarName}}() *cobra.Command { {{#operation}}
 	{{#queryParams}}utils.AddFlag({{operationId}}Cmd.Flags(), "{{{dataType}}}", "{{paramName}}", "{{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}{{/defaultValue}}", "{{description}}{{#required}} - REQUIRED{{/required}}{{#allowableValues}} Valid values: {{#values}}{{.}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}")
 	{{#hasMore}}{{/hasMore}}{{/queryParams}}{{operationId}}Cmd.SetUsageTemplate(fmt.Sprintf("%s\nOperation:\n  %s %s\n%s", {{operationId}}Cmd.UsageTemplate(), "{{httpMethod}}", "{{path}}", utils.FormatPermissions([]string{ {{#permissions}}"{{.}}", {{/permissions}} })))
 	utils.AddFileFlagIfUpsert({{operationId}}Cmd.Flags(), "{{httpMethod}}", `{{#bodyParam}}{{jsonSchema}}{{/bodyParam}}`)
+	{{#queryParams}}{{#required}}{{operationId}}Cmd.MarkFlagRequired("{{paramName}}"){{/required}}{{/queryParams}}
 	{{#responses}}{{#-first}}utils.AddPaginateFlagsIfListingResponse({{operationId}}Cmd.Flags(), "{{httpMethod}}", `{{jsonSchema}}`){{/-first}}{{/responses}}
 	{{classVarName}}Cmd.AddCommand({{operationId}}Cmd)
 	{{/operation}}


### PR DESCRIPTION
responsemgt issue fixed. Now when invoking `gc responsemgt responses list` without providing libraryId, it will bring up help page and asking users to provide the flag. (example below)
![image](https://user-images.githubusercontent.com/39736275/111373892-d7cf1a80-8672-11eb-9635-27239fed1f6b.png)
