### PR TITLE
DEVENGAGE-554-Add-nested-commands

### DIFF
--- a/resources/sdk/clisdkclient/scripts/post-process.js
+++ b/resources/sdk/clisdkclient/scripts/post-process.js
@@ -8,22 +8,22 @@ try {
 	const rootPath = path.resolve(process.argv[2]);
 	const duplicateMappingsPath = path.resolve(process.argv[3]);
 	const topLevelCommandsPath = path.resolve(process.argv[4]);
-	const resourceDefinitionsPath = path.join(path.dirname(require.main.filename), "../resources/resourceDefinitions.json")
+	const resourceDefinitionsPath = path.join(path.dirname(require.main.filename), '../resources/resourceDefinitions.json');
 
 	console.log(`rootPath=${rootPath}`);
 	console.log(`duplicateMappingsPath=${duplicateMappingsPath}`);
 	console.log(`topLevelCommandsPath=${topLevelCommandsPath}`);
 
-	const resourceDefinitions = JSON.parse(fs.readFileSync(resourceDefinitionsPath, 'utf8'))
-	const duplicateMappings = JSON.parse(fs.readFileSync(duplicateMappingsPath, 'utf8'))
-	const topLevelCommands = JSON.parse(fs.readFileSync(topLevelCommandsPath, 'utf8'))
+	const resourceDefinitions = JSON.parse(fs.readFileSync(resourceDefinitionsPath, 'utf8'));
+	const duplicateMappings = JSON.parse(fs.readFileSync(duplicateMappingsPath, 'utf8'));
+	const topLevelCommands = JSON.parse(fs.readFileSync(topLevelCommandsPath, 'utf8'));
 
-	const rootFileName = rootPath.split("/").pop()
-	const rootDir = rootPath.replace(rootFileName, "")
+	const rootFileName = rootPath.split('/').pop();
+	const rootDir = rootPath.replace(rootFileName, '');
 
-	generateSuperCommandFiles(rootDir, topLevelCommands)
-	generateRootFiles(rootDir, resourceDefinitions, duplicateMappings)
-	processRoot(rootDir, rootFileName, resourceDefinitions, duplicateMappings, topLevelCommands)
+	generateSuperCommandFiles(rootDir, topLevelCommands);
+	generateRootFiles(rootDir, resourceDefinitions, duplicateMappings, topLevelCommands);
+	processRoot(rootDir, rootFileName, resourceDefinitions, duplicateMappings, topLevelCommands);
 } catch (err) {
 	process.exitCode = 1;
 	console.log(err);
@@ -47,28 +47,53 @@ var {{=it.supercommand}}Cmd = &cobra.Command{
 func Cmd{{=it.supercommand}}() *cobra.Command {
 	return {{=it.supercommand}}Cmd
 }
-`
+`;
 	for (const supercommand of topLevelCommands) {
-		const commandPath = path.join(rootDir, supercommand)
-		const commandFile = path.join(commandPath, `${supercommand}.go`)
+		const commandPath = path.join(rootDir, supercommand);
+		const commandFile = path.join(commandPath, `${supercommand}.go`);
 		if (!fs.existsSync(commandFile)) {
-			fs.mkdirSync(commandPath)
-			writeTemplate(templateString, { supercommand: supercommand }, commandFile)
+			fs.mkdirSync(commandPath);
+			writeTemplate(templateString, { supercommand: supercommand }, commandFile);
 		}
 	}
 }
 
 // Generates root files to attach subcommands to supercommands
-function generateRootFiles(rootDir, resourceDefinitions, duplicateMappings) {
-	let commandMappings = new Map()
+function generateRootFiles(rootDir, resourceDefinitions, duplicateMappings, topLevelCommands) {
+	let commandMappings = new Map();
 	for (const path of Object.keys(resourceDefinitions)) {
-		const supercommand = resourceDefinitions[path].supercommand
-		if (supercommand !== undefined) {
-			let entry = commandMappings.get(supercommand) || new Set()
-			const key = `${resourceDefinitions[path].name}_${supercommand}`
-			const value = duplicateMappings[key]
-			entry.add(value ? key : resourceDefinitions[path].name)
-			commandMappings.set(supercommand, entry)
+		var commandName = resourceDefinitions[path].name;
+		if (resourceDefinitions[path].supercommand) {
+			const supercommandlist = resourceDefinitions[path].supercommand.split('.');
+
+			let nonRootSuperCommands = new Set();
+			for (const command of supercommandlist) {
+				if (!topLevelCommands.includes(command)) {
+					nonRootSuperCommands.add(command);
+				}
+			}
+
+			generateSuperCommandFiles(rootDir, nonRootSuperCommands);
+
+			supercommandlist.push(commandName);
+
+			for (var i = supercommandlist.length - 1; i >= 1; i--) {
+				let currentCommand = supercommandlist[i];
+				let currentSuperCommand = supercommandlist[i - 1];
+				if (i > 1) {
+					for (const duplicateCommand of Object.keys(duplicateMappings)) {
+						if (duplicateCommand === currentSuperCommand + '_' + supercommandlist[i - 2]) {
+							currentSuperCommand = currentSuperCommand + '_' + supercommandlist[i - 2];
+							break;
+						}
+					}
+				}
+				let entry = commandMappings.get(currentSuperCommand) || new Set();
+				let key = `${currentCommand}_${currentSuperCommand}`;
+				let value = duplicateMappings[key];
+				entry.add(value ? key : currentCommand);
+				commandMappings.set(currentSuperCommand, entry);
+			}
 		}
 	}
 
@@ -82,54 +107,65 @@ import (
 func init() {
 	{{=it.addcommand}}
 }
-`
+`;
 
 	for (const [supercommand, value] of commandMappings) {
-		let imports = []
-		let addcommands = []
+		let imports = [];
+		let addcommands = [];
 		for (const subcommand of value) {
-			imports.push(`"github.com/mypurecloud/platform-client-sdk-cli/build/gc/cmd/${subcommand}"`)
-			addcommands.push(`${supercommand}Cmd.AddCommand(${subcommand}.Cmd${subcommand}())`)
+			imports.push(`"github.com/mypurecloud/platform-client-sdk-cli/build/gc/cmd/${subcommand}"`);
+			addcommands.push(`${supercommand}Cmd.AddCommand(${subcommand}.Cmd${subcommand}())`);
 		}
 
-		const commandPath = path.join(rootDir, supercommand)
-		const commandFile = path.join(commandPath, `${supercommand}root.go`)
+		const commandPath = path.join(rootDir, supercommand);
+		const commandFile = path.join(commandPath, `${supercommand}root.go`);
 
-		writeTemplate(templateString, { supercommand: supercommand, import: imports.join("\n\t"), addcommand: addcommands.join("\n\t")}, commandFile)
-  	}
+		writeTemplate(
+			templateString,
+			{ supercommand: supercommand, import: imports.join('\n\t'), addcommand: addcommands.join('\n\t') },
+			commandFile
+		);
+	}
 }
 
 // Adds imports for every command and attaches them to the root
 function processRoot(rootDir, rootFileName, resourceDefinitions, duplicateMappings, topLevelCommands) {
-	let exclusionList = new Set()
-	exclusionList.add(rootFileName)
+	let exclusionList = new Set();
+	exclusionList.add(rootFileName);
 	for (const resourceDefinition of Object.values(resourceDefinitions)) {
-		if (resourceDefinition.supercommand !== undefined && !topLevelCommands.includes(resourceDefinition.name)) {
-			exclusionList.add(resourceDefinition.name)
+		if (resourceDefinition.supercommand !== undefined) {
+			const supercommandlist = resourceDefinition.supercommand.split('.');
+
+			if (!topLevelCommands.includes(resourceDefinition.name)) exclusionList.add(resourceDefinition.name);
+			for (const command of supercommandlist) {
+				if (!topLevelCommands.includes(command)) {
+					exclusionList.add(command);
+				}
+			}
 		}
 	}
 	for (const duplicateCommand of Object.keys(duplicateMappings)) {
-		exclusionList.add(duplicateCommand)
+		exclusionList.add(duplicateCommand);
 	}
 
-	let addCommands = []
-	let addImports = []
+	let addCommands = [];
+	let addImports = [];
 
-	const dir = fs.opendirSync(rootDir)
-	let dirent
+	const dir = fs.opendirSync(rootDir);
+	let dirent;
 	while ((dirent = dir.readSync()) !== null) {
-		if (exclusionList.has(dirent.name)) continue
+		if (exclusionList.has(dirent.name)) continue;
 		// imports for packages under cmd
-		addImports.push(`"github.com/mypurecloud/platform-client-sdk-cli/build/gc/cmd/${dirent.name}"`)
+		addImports.push(`"github.com/mypurecloud/platform-client-sdk-cli/build/gc/cmd/${dirent.name}"`);
 		let packageName = `${dirent.name}`;
 		// adding each command to the rootCmd
-		addCommands.push(`rootCmd.AddCommand(${packageName}.Cmd${packageName}())`)
+		addCommands.push(`rootCmd.AddCommand(${packageName}.Cmd${packageName}())`);
 	}
-	dir.closeSync()
+	dir.closeSync();
 
-	const rootPath = path.join(rootDir, rootFileName)
+	const rootPath = path.join(rootDir, rootFileName);
 	let templateString = fs.readFileSync(rootPath, 'utf8');
-	writeTemplate(templateString, { addImports: addImports.join("\n\t"), addCommands: addCommands.join("\n\t") }, rootPath)
+	writeTemplate(templateString, { addImports: addImports.join('\n\t'), addCommands: addCommands.join('\n\t') }, rootPath);
 }
 
 function writeTemplate(templateString, templateObj, filePath) {

--- a/resources/sdk/clisdkclient/scripts/post-process.js
+++ b/resources/sdk/clisdkclient/scripts/post-process.js
@@ -80,16 +80,21 @@ function generateRootFiles(rootDir, resourceDefinitions, duplicateMappings, topL
 			for (var i = supercommandlist.length - 1; i >= 1; i--) {
 				let currentCommand = supercommandlist[i];
 				let currentSuperCommand = supercommandlist[i - 1];
+				let key;
 				if (i > 1) {
 					for (const duplicateCommand of Object.keys(duplicateMappings)) {
-						if (duplicateCommand === currentSuperCommand + '_' + supercommandlist[i - 2]) {
-							currentSuperCommand = currentSuperCommand + '_' + supercommandlist[i - 2];
+						if (duplicateCommand.includes(currentSuperCommand + '_' + supercommandlist[i - 2])) {
+							if (duplicateCommand.startsWith(currentCommand)) {
+								key = duplicateCommand;
+							} else {
+								currentSuperCommand = duplicateCommand;
+							}
 							break;
 						}
 					}
 				}
 				let entry = commandMappings.get(currentSuperCommand) || new Set();
-				let key = `${currentCommand}_${currentSuperCommand}`;
+				key = key ? key : `${currentCommand}_${currentSuperCommand}`;
 				let value = duplicateMappings[key];
 				entry.add(value ? key : currentCommand);
 				commandMappings.set(currentSuperCommand, entry);

--- a/resources/sdk/clisdkclient/scripts/prebuild-postrun.js
+++ b/resources/sdk/clisdkclient/scripts/prebuild-postrun.js
@@ -9,7 +9,7 @@ try {
 		basePath: 'https://api.mypurecloud.com',
 		packageName: 'platform-client',
 		packageVersion: version.displayFull,
-		httpUserAgent: 'PureCloud SDK'
+		httpUserAgent: 'PureCloud SDK',
 	};
 
 	fs.writeFileSync(swaggerCodegenConfigFilePath, JSON.stringify(config, null, 2));

--- a/resources/sdk/clisdkclient/scripts/preprocess-swagger.js
+++ b/resources/sdk/clisdkclient/scripts/preprocess-swagger.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const childProcess = require('child_process');
 const { each } = require('lodash');
+const maxFileBufferSize = 1024 * 1024 * 1024;
 
 try {
 	const newSwaggerPath = process.argv[2];
@@ -174,7 +175,7 @@ function downloadFile(url) {
 		i++;
 		console.log(`Downloading file: ${url}`);
 		// Source: https://www.npmjs.com/package/download-file-sync
-		var file = childProcess.execFileSync('curl', ['--silent', '-L', url], { encoding: 'utf8', maxBuffer: 1024 * 1024 * 1024 });
+		var file = childProcess.execFileSync('curl', ['--silent', '-L', url], { encoding: 'utf8', maxBuffer: maxFileBufferSize });
 		if (!file || file === '') {
 			console.log(`File was empty! sleeping for 5 seconds. Retries left: ${10 - i}`);
 			childProcess.execFileSync('curl', ['--silent', 'https://httpbin.org/delay/10'], { encoding: 'utf8' });

--- a/resources/sdk/clisdkclient/scripts/preprocess-swagger.js
+++ b/resources/sdk/clisdkclient/scripts/preprocess-swagger.js
@@ -1,41 +1,42 @@
-const fs = require('fs')
-const path = require('path')
-const childProcess = require('child_process')
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+const { each } = require('lodash');
 
 try {
-	const newSwaggerPath = process.argv[2]
-	const saveNewSwaggerPath = process.argv[3]
-	const saveDuplicateMappingsPath = process.argv[4]
-	const saveSuperCommandsPath = process.argv[5]
+	const newSwaggerPath = process.argv[2];
+	const saveNewSwaggerPath = process.argv[3];
+	const saveDuplicateMappingsPath = process.argv[4];
+	const saveSuperCommandsPath = process.argv[5];
 
-	let newSwagger = retrieveSwagger(newSwaggerPath)
-	const definitionsPath = path.join(path.dirname(require.main.filename), "../resources/resourceDefinitions.json")
-	const resourceDefinitions = JSON.parse(fs.readFileSync(definitionsPath, 'utf8'))
+	let newSwagger = retrieveSwagger(newSwaggerPath);
+	const definitionsPath = path.join(path.dirname(require.main.filename), '../resources/resourceDefinitions.json');
+	const resourceDefinitions = JSON.parse(fs.readFileSync(definitionsPath, 'utf8'));
 
-	let [superCommands, includedSwaggerPathObjects] = initialProcessOfDefinitions(newSwagger, resourceDefinitions)
-	let duplicateCommandMappings = findDuplicateCommandMappings(superCommands, includedSwaggerPathObjects, resourceDefinitions)
-	newSwagger["paths"] = processDefinitions(duplicateCommandMappings, includedSwaggerPathObjects, resourceDefinitions)
+	let [superCommands, includedSwaggerPathObjects] = initialProcessOfDefinitions(newSwagger, resourceDefinitions);
+	let duplicateCommandMappings = findDuplicateCommandMappings(superCommands, includedSwaggerPathObjects, resourceDefinitions);
+	newSwagger['paths'] = processDefinitions(duplicateCommandMappings, includedSwaggerPathObjects, resourceDefinitions);
 
 	if (saveNewSwaggerPath) {
-		console.log(`Writing new swagger to ${saveNewSwaggerPath}`)
-		fs.writeFileSync(saveNewSwaggerPath, JSON.stringify(newSwagger))
+		console.log(`Writing new swagger to ${saveNewSwaggerPath}`);
+		fs.writeFileSync(saveNewSwaggerPath, JSON.stringify(newSwagger));
 	}
 
 	if (saveDuplicateMappingsPath) {
-		console.log(`Writing duplicate mappings to ${saveDuplicateMappingsPath}`)
+		console.log(`Writing duplicate mappings to ${saveDuplicateMappingsPath}`);
 		// from https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map
-		const mapToObj = m => {
+		const mapToObj = (m) => {
 			return Array.from(m).reduce((obj, [key, value]) => {
-				obj[key] = value
-				return obj
-			}, {})
-		}
-		fs.writeFileSync(saveDuplicateMappingsPath, JSON.stringify(mapToObj(duplicateCommandMappings)))
+				obj[key] = value;
+				return obj;
+			}, {});
+		};
+		fs.writeFileSync(saveDuplicateMappingsPath, JSON.stringify(mapToObj(duplicateCommandMappings)));
 	}
 
 	if (saveSuperCommandsPath) {
-		console.log(`Writing top level commands to ${saveSuperCommandsPath}`)
-		fs.writeFileSync(saveSuperCommandsPath, JSON.stringify(Array.from(superCommands)))
+		console.log(`Writing top level commands to ${saveSuperCommandsPath}`);
+		fs.writeFileSync(saveSuperCommandsPath, JSON.stringify(Array.from(superCommands)));
 	}
 } catch (err) {
 	process.exitCode = 1;
@@ -43,133 +44,143 @@ try {
 }
 
 function processDefinitions(duplicateCommandMappings, includedSwaggerPathObjects, resourceDefinitions) {
-	let paths = {}
+	let paths = {};
 	for (const path of Object.keys(includedSwaggerPathObjects)) {
 		// Override tags if possible
 		for (let value of Object.values(includedSwaggerPathObjects[path])) {
-			let commandName = resourceDefinitions[path].name || value.tags[0]
-			commandName = commandName.toLowerCase().replace(" ", "")
+			let commandName = resourceDefinitions[path].name || value.tags[0];
+			commandName = commandName.toLowerCase().replace(' ', '');
 
-			const supercommand = resourceDefinitions[path].supercommand
-			if (supercommand) {
+			let supercommandList = resourceDefinitions[path].supercommand;
+			if (supercommandList) {
 				// Custom commandName if it's a duplicate
+				let supercommandArray = supercommandList.split('.');
+				let supercommand = supercommandArray.pop();
+				for (var i = supercommandArray.length - 1; i >= 0; i--) {
+					supercommand += '_' + supercommandArray[i];
+				}
 				if (duplicateCommandMappings.get(`${commandName}_${supercommand}`)) {
-					commandName = `${commandName}_${supercommand}`
+					commandName = `${commandName}_${supercommand}`;
 				}
 			}
-			value.tags = [commandName]
+			value.tags = [commandName];
 		}
 
 		// Override operationId if possible
 		for (const method of Object.keys(includedSwaggerPathObjects[path])) {
-			if (!Object.keys(resourceDefinitions[path]).includes(method)) continue
+			if (!Object.keys(resourceDefinitions[path]).includes(method)) continue;
 			if (resourceDefinitions[path][method].name !== undefined) {
-				includedSwaggerPathObjects[path][method].operationId = `SWAGGER_OVERRIDE_${resourceDefinitions[path][method].name}`
+				includedSwaggerPathObjects[path][method].operationId = `SWAGGER_OVERRIDE_${resourceDefinitions[path][method].name}`;
 			}
 		}
 
 		// Exclude HTTP methods if possible
-		let includedMethods = []
-		const httpMethods = ["get", "delete", "put", "patch", "post"]
+		let includedMethods = [];
+		const httpMethods = ['get', 'delete', 'put', 'patch', 'post'];
 		for (const httpMethod of Object.keys(resourceDefinitions[path])) {
-			if (!httpMethods.includes(httpMethod)) continue
-			includedMethods.push(httpMethod)
+			if (!httpMethods.includes(httpMethod)) continue;
+			includedMethods.push(httpMethod);
 		}
 
-		paths[path] = {}
+		paths[path] = {};
 		if (includedMethods.length > 0) {
 			for (const method of includedMethods) {
-				paths[path][method] = includedSwaggerPathObjects[path][method]
+				paths[path][method] = includedSwaggerPathObjects[path][method];
 			}
 		} else {
-			paths[path] = includedSwaggerPathObjects[path]
+			paths[path] = includedSwaggerPathObjects[path];
 		}
 	}
 
-	return paths
+	return paths;
 }
 
 function findDuplicateCommandMappings(superCommands, includedSwaggerPathObjects, resourceDefinitions) {
-	let duplicateCommandMappings = new Map()
+	let duplicateCommandMappings = new Map();
 	for (const path of Object.keys(includedSwaggerPathObjects)) {
 		for (let value of Object.values(includedSwaggerPathObjects[path])) {
-			let commandName = resourceDefinitions[path].name || value.tags[0]
-			commandName = commandName.toLowerCase().replace(" ", "")
+			let commandName = resourceDefinitions[path].name || value.tags[0];
+			commandName = commandName.toLowerCase().replace(' ', '');
 
-			const supercommand = resourceDefinitions[path].supercommand
+			let supercommandList = resourceDefinitions[path].supercommand;
 			// Only need to work on duplicate subcommands, no one would try to create 2 `gc users` commands for example
-			if (supercommand) {
-				const existingCommandName = duplicateCommandMappings.get(commandName)
+			if (supercommandList) {
+				const existingCommandName = duplicateCommandMappings.get(commandName);
+				let supercommandSplit = supercommandList.split('.');
+				let supercommand = supercommandSplit.pop();
+				for (var i = supercommandSplit.length - 1; i >= 0; i--) {
+					supercommand += '_' + supercommandSplit[i];
+				}
 				// Duplicate found
 				if (superCommands.has(commandName) || (existingCommandName && existingCommandName !== supercommand)) {
-					duplicateCommandMappings.set(`${commandName}_${existingCommandName}`, existingCommandName)
-					commandName = `${commandName}_${supercommand}`
+					duplicateCommandMappings.set(`${commandName}_${existingCommandName}`, existingCommandName);
+					commandName = `${commandName}_${supercommand}`;
 				}
-				duplicateCommandMappings.set(commandName, supercommand)
+				duplicateCommandMappings.set(commandName, supercommand);
 			}
 		}
 	}
 
 	// Remove all non-duplicates from the mappings now
-	duplicateCommandMappings.forEach((values, keys)=> {
-		if (!keys.includes("_"))
-			duplicateCommandMappings.delete(keys)
-	})
+	duplicateCommandMappings.forEach((values, keys) => {
+		if (!keys.includes('_')) duplicateCommandMappings.delete(keys);
+	});
 
-	return duplicateCommandMappings
+	return duplicateCommandMappings;
 }
 
 function initialProcessOfDefinitions(newSwagger, resourceDefinitions) {
-	let superCommands = new Set()
-	let includedSwaggerPathObjects = {}
-	for (const path of Object.keys(newSwagger["paths"])) {
+	let superCommands = new Set();
+	let includedSwaggerPathObjects = {};
+	for (const path of Object.keys(newSwagger['paths'])) {
 		if (Object.keys(resourceDefinitions).includes(path)) {
-			includedSwaggerPathObjects[path] = newSwagger["paths"][path]
+			includedSwaggerPathObjects[path] = newSwagger['paths'][path];
 
 			for (let value of Object.values(includedSwaggerPathObjects[path])) {
-				let commandName = resourceDefinitions[path].name || value.tags[0]
-				commandName = commandName.toLowerCase().replace(" ", "")
-				const supercommand = resourceDefinitions[path].supercommand
-				if (!supercommand)
-					superCommands.add(commandName)
-				else
-					superCommands.add(supercommand.toLowerCase())
+				let commandName = resourceDefinitions[path].name || value.tags[0];
+				commandName = commandName.toLowerCase().replace(' ', '');
+				const supercommandList = resourceDefinitions[path].supercommand;
+				if (!supercommandList) superCommands.add(commandName);
+				else {
+					const supercommandArray = supercommandList.split('.');
+					superCommands.add(supercommandArray[0].toLowerCase());
+				}
 			}
 		}
 	}
 
-	return [superCommands, includedSwaggerPathObjects]
+	return [superCommands, includedSwaggerPathObjects];
 }
 
 function retrieveSwagger(newSwaggerPath) {
-	let newSwagger
+	let newSwagger;
 	// Retrieve new swagger
 	if (fs.existsSync(newSwaggerPath)) {
-		console.log(`Loading new swagger from disk: ${newSwaggerPath}`)
-		newSwagger = JSON.parse(fs.readFileSync(newSwaggerPath, 'utf8'))
+		console.log(`Loading new swagger from disk: ${newSwaggerPath}`);
+		newSwagger = JSON.parse(fs.readFileSync(newSwaggerPath, 'utf8'));
 	} else if (newSwaggerPath.toLowerCase().startsWith('http')) {
-		console.log(`Downloading new swagger from: ${newSwaggerPath}`)
-		newSwagger = JSON.parse(downloadFile(newSwaggerPath))
+		console.log(`Downloading new swagger from: ${newSwaggerPath}`);
+		newSwagger = JSON.parse(downloadFile(newSwaggerPath));
 	} else {
-		throw `Invalid newSwaggerPath: ${newSwaggerPath}`
+		throw `Invalid newSwaggerPath: ${newSwaggerPath}`;
 	}
 
-	return newSwagger
+	return newSwagger;
 }
 
 function downloadFile(url) {
-	var i = 0
+	var i = 0;
 	while (i < 10) {
-		i++
-		console.log(`Downloading file: ${url}`)
+		i++;
+		console.log(`Downloading file: ${url}`);
 		// Source: https://www.npmjs.com/package/download-file-sync
-		var file = childProcess.execFileSync('curl', ['--silent', '-L', url], { encoding: 'utf8', maxBuffer: 1024 * 1024 * 1024 })
+		var file = childProcess.execFileSync('curl', ['--silent', '-L', url], { encoding: 'utf8', maxBuffer: 1024 * 1024 * 1024 });
 		if (!file || file === '') {
-			console.log(`File was empty! sleeping for 5 seconds. Retries left: ${10 - i}`)
-			childProcess.execFileSync('curl', ['--silent', 'https://httpbin.org/delay/10'], { encoding: 'utf8' })
+			console.log(`File was empty! sleeping for 5 seconds. Retries left: ${10 - i}`);
+			childProcess.execFileSync('curl', ['--silent', 'https://httpbin.org/delay/10'], { encoding: 'utf8' });
 		} else {
-			return file
+			return file;
 		}
 	}
-	throw 'Failed to get contents for file!'
+	throw 'Failed to get contents for file!';
 }


### PR DESCRIPTION
Add nested commands compatibility. Since the files are auto-formatted by Prettier, it's a little messy to look through. 

I think the code is working for the scenario described in the ticket and Andrew Johnson's comment. It now uses dot format to add nested commands. If the command is single-leveled, it works as usual. Also if a particular command, or several commands in between are undefined, it will automatically create that command. 

However, because we are bringing in the ability to add multiple levels nested commands, I suspect and worry that there are some edge cases or scenarios I haven't covered, and it might not work perfectly for all the possibilities. But as users and we experiment more, I believe we can gradually discover most of them, and if there are any major issues, we can create tickets and resolve them then. 