### PR TITLE
Passing in cmd.Flags() to CommandService.DetermineAction

### DIFF
--- a/resources/sdk/clisdkclient/extensions/cmd/members/addmembers.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/members/addmembers.go
@@ -51,7 +51,7 @@ var addCmd = &cobra.Command{
 		groupId, args := args[0], args[1:]
 		path := strings.Replace(getMembersOperation.Path, "{groupId}", fmt.Sprintf("%v", groupId), -1)
 
-		currentVersion := getGroupVersion(path)
+		currentVersion := getGroupVersion(path, cmd)
 
 		inputData := utils.ResolveInputData(cmd)
 		body := &addGroupMembersBody{}
@@ -80,8 +80,8 @@ var addCmd = &cobra.Command{
 	},
 }
 
-func getGroupVersion(path string) int {
-	retryFunc := CommandService.DetermineAction(getMembersOperation.Method, path, nil)
+func getGroupVersion(path string, cmd *cobra.Command) int {
+	retryFunc := CommandService.DetermineAction(getMembersOperation.Method, path, cmd.Flags())
 	retryConfig := &retry.RetryConfiguration{
 		RetryWaitMin: 5 * time.Second,
 		RetryWaitMax: 60 * time.Second,

--- a/resources/sdk/clisdkclient/extensions/cmd/usage/usagequery.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/usage/usagequery.go
@@ -42,7 +42,7 @@ var queryUsageCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		timeout, _ := cmd.Flags().GetInt("timeout")
 
-		retryFunc := CommandService.DetermineAction(usageQueryOperation.Method, usageQueryOperation.Path, nil)
+		retryFunc := CommandService.DetermineAction(usageQueryOperation.Method, usageQueryOperation.Path, cmd.Flags())
 		results, err := retryFunc(nil)
 		if err != nil {
 			logger.Fatal(err)
@@ -61,7 +61,7 @@ var queryUsageCmd = &cobra.Command{
 			for true {
 				path := usageQueryResultsOperation.Path
 				targetURI := strings.Replace(path, "{executionId}", fmt.Sprintf("%v", usageSubmitResponse.ExecutionID), -1)
-				retryFunc := CommandService.DetermineAction(usageQueryResultsOperation.Method, targetURI, nil)
+				retryFunc := CommandService.DetermineAction(usageQueryResultsOperation.Method, targetURI, cmd.Flags())
 				rawData, commandErr := retryFunc(nil)
 				if commandErr != nil {
 					logger.Fatal(commandErr)


### PR DESCRIPTION
Passing in cmd.Flags() to CommandService.DetermineAction instead of nil in custom commands to avoid nil pointer bug