### PR TITLE
no-jira use public registry

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,3655 +1,29 @@
 {
   "name": "purecloud-api-sdk-common",
   "version": "1.0.1",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "purecloud-api-sdk-common",
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "archiver": "^1.3.0",
-        "commander": "^2.9.0",
-        "dateformat": "^3.0.3",
-        "dot": "^1.1.3",
-        "fs-extra": "^5.0.0",
-        "github-api-promise": "^1.12.2",
-        "json-schema-deref-sync": "^0.13.0",
-        "klaw-sync": "^3.0.2",
-        "lodash": "^4.17.19",
-        "lognext": "0.0.4",
-        "mdjavadoc-api": "^1.0.4",
-        "moment-timezone": "^0.5.11",
-        "mustache": "^2.3.0",
-        "pluralize": "^3.1.0",
-        "purecloud-platform-client-v2": "^109.0.0",
-        "q": "^1.4.1",
-        "request": "^2.67.0",
-        "request-promise": "^4.2.2",
-        "semver": "^5.5.0",
-        "superagent": "^6.0.1",
-        "wget": "^0.0.1",
-        "winston": "^2.3.1",
-        "yamljs": "^0.2.8"
-      },
-      "bin": {
-        "sdk-builder": "sdkBuilder.js"
-      },
-      "devDependencies": {
-        "browserify": "^16.1.1",
-        "rollup-plugin-json": "^2.3.0"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "0.0.38",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/@types/estree/-/estree-0.0.38.tgz",
-      "integrity": "sha1-wb5AqpM3I8YIggqZo3OhbSFaHKI=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha1-o92NpOuEqZbDbjMd+Y2Cq9drUW4=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha1-EUyV1kU55T3t4j3oudlt98euKvg=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/archiver": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/archiver/-/archiver-1.3.0.tgz",
-      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^1.3.0",
-        "async": "^2.0.0",
-        "buffer-crc32": "^0.2.1",
-        "glob": "^7.0.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0",
-        "tar-stream": "^1.5.0",
-        "walkdir": "^0.0.11",
-        "zip-stream": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "graceful-fs": "^4.1.0",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/archiver/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/assert": {
-      "version": "1.5.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "util": "0.10.3"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/assert/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/assert/node_modules/util": {
-      "version": "0.10.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.1"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/async/-/async-2.6.3.tgz",
-      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
-      "license": "MIT"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bl": {
-      "version": "1.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
-      "license": "MIT"
-    },
-    "node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/browser-pack": {
-      "version": "6.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browser-pack/-/browser-pack-6.1.0.tgz",
-      "integrity": "sha1-w0uhDQuc4WK1ryJ8cTHJLC7NV3Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "combine-source-map": "~0.8.0",
-        "defined": "^1.0.0",
-        "JSONStream": "^1.0.3",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.0",
-        "umd": "^3.0.0"
-      },
-      "bin": {
-        "browser-pack": "bin/cmd.js"
-      }
-    },
-    "node_modules/browser-resolve": {
-      "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browser-resolve/-/browser-resolve-2.0.0.tgz",
-      "integrity": "sha1-mbcwTLOS+Nc9unQbstfaKMbXhCs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.17.0"
-      }
-    },
-    "node_modules/browserify": {
-      "version": "16.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify/-/browserify-16.5.2.tgz",
-      "integrity": "sha1-2SaDXpKA+l/Vf1vDAfLvJKly3f4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert": "^1.4.0",
-        "browser-pack": "^6.0.1",
-        "browser-resolve": "^2.0.0",
-        "browserify-zlib": "~0.2.0",
-        "buffer": "~5.2.1",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "^1.6.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "~1.0.0",
-        "crypto-browserify": "^3.0.0",
-        "defined": "^1.0.0",
-        "deps-sort": "^2.0.0",
-        "domain-browser": "^1.2.0",
-        "duplexer2": "~0.1.2",
-        "events": "^2.0.0",
-        "glob": "^7.1.0",
-        "has": "^1.0.0",
-        "htmlescape": "^1.1.0",
-        "https-browserify": "^1.0.0",
-        "inherits": "~2.0.1",
-        "insert-module-globals": "^7.0.0",
-        "JSONStream": "^1.0.3",
-        "labeled-stream-splicer": "^2.0.0",
-        "mkdirp-classic": "^0.5.2",
-        "module-deps": "^6.2.3",
-        "os-browserify": "~0.3.0",
-        "parents": "^1.0.1",
-        "path-browserify": "~0.0.0",
-        "process": "~0.11.0",
-        "punycode": "^1.3.2",
-        "querystring-es3": "~0.2.0",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.4",
-        "shasum": "^1.0.0",
-        "shell-quote": "^1.6.1",
-        "stream-browserify": "^2.0.0",
-        "stream-http": "^3.0.0",
-        "string_decoder": "^1.1.1",
-        "subarg": "^1.0.0",
-        "syntax-error": "^1.1.1",
-        "through2": "^2.0.0",
-        "timers-browserify": "^1.0.1",
-        "tty-browserify": "0.0.1",
-        "url": "~0.11.0",
-        "util": "~0.10.1",
-        "vm-browserify": "^1.0.0",
-        "xtend": "^4.0.0"
-      },
-      "bin": {
-        "browserify": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "node_modules/browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/browserify-rsa": {
-      "version": "4.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-      "integrity": "sha1-sv0Gtbda4pf3zi3GUfkY9b4VjI0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^5.0.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "node_modules/browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
-        "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      }
-    },
-    "node_modules/browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "~1.0.5"
-      }
-    },
-    "node_modules/browserify/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/browserify/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/browserify/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha1-3Vf6DxCaxZxgJHkETcp7iz0LcdY=",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
-      "license": "MIT"
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "license": "MIT"
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cached-path-relative": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha1-oT30GW0md2IgzDNW6xR6Utuixts=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "license": "Apache-2.0"
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/combine-source-map": {
-      "version": "0.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/combine-source-map/-/combine-source-map-0.8.0.tgz",
-      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-source-map": "~1.1.0",
-        "inline-source-map": "~0.6.0",
-        "lodash.memoize": "~3.0.3",
-        "source-map": "~0.5.3"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
-      "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
-      "license": "MIT"
-    },
-    "node_modules/compress-commons": {
-      "version": "1.2.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/compress-commons/-/compress-commons-1.2.2.tgz",
-      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.1",
-        "crc32-stream": "^2.0.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/compress-commons/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/compress-commons/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/console-browserify": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
-      "dev": true
-    },
-    "node_modules/constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/convert-source-map/-/convert-source-map-1.1.3.tgz",
-      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw=",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "license": "MIT"
-    },
-    "node_modules/crc": {
-      "version": "3.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crc32-stream/-/crc32-stream-2.0.0.tgz",
-      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-      "license": "MIT",
-      "dependencies": {
-        "crc": "^3.4.4",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/crc32-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/create-ecdh": {
-      "version": "4.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.5.3"
-      }
-    },
-    "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cycle": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dag-map": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dag-map/-/dag-map-1.0.2.tgz",
-      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc=",
-      "license": "MIT"
-    },
-    "node_modules/dash-ast": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dash-ast/-/dash-ast-1.0.0.tgz",
-      "integrity": "sha1-EgKbpfsviqbwqGF5WyPBtLbCfTc=",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/deps-sort": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/deps-sort/-/deps-sort-2.0.1.tgz",
-      "integrity": "sha1-nf3IdtK87DOGtoKaxSFizan6II0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "JSONStream": "^1.0.3",
-        "shasum-object": "^1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "deps-sort": "bin/cmd.js"
-      }
-    },
-    "node_modules/des.js": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/detective": {
-      "version": "5.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/detective/-/detective-5.2.0.tgz",
-      "integrity": "sha1-/rKnfoW5BOzepFmtiXzJCpm9Kns=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.6.1",
-        "defined": "^1.0.0",
-        "minimist": "^1.1.1"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/domain-browser": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4",
-        "npm": ">=1.2"
-      }
-    },
-    "node_modules/dot": {
-      "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dot/-/dot-1.1.3.tgz",
-      "integrity": "sha1-NRNg4Ap0i86aH48nwAw5Sn5OHp8=",
-      "engines": [
-        "node >=0.2.6"
-      ],
-      "license": "MIT",
-      "bin": {
-        "dottojs": "bin/dot-packer"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/events/-/events-2.1.0.tgz",
-      "integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-      "engines": {
-        "node": "> 0.1.90"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
-      "license": "MIT"
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M=",
-      "license": "MIT"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "1.2.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha1-v2muopcpgmdfAIZTQrmCmG9rjdk=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-      "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "license": "MIT"
-    },
-    "node_modules/get-assigned-identifiers": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha1-bb9BHeZIy6+NkWnrsNLVdhkeL/E=",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/github-api-promise": {
-      "version": "1.13.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/github-api-promise/-/github-api-promise-1.13.4.tgz",
-      "integrity": "sha1-/gqH6UF4vyavpBM0C2e4KxVeL3E=",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.5.1",
-        "lodash": "^4.17.10",
-        "lognext": "0.0.4",
-        "q": "^1.5.1",
-        "superagent": "^6.0.1",
-        "superagent-bluebird-promise": "^4.2.0",
-        "urlencode": "^1.1.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
-      "license": "ISC"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
-    },
-    "node_modules/inline-source-map": {
-      "version": "0.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inline-source-map/-/inline-source-map-0.6.2.tgz",
-      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.5.3"
-      }
-    },
-    "node_modules/insert-module-globals": {
-      "version": "7.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
-      "integrity": "sha1-1eMxhRgaTh8zsV978QDukYkNXLM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.5.2",
-        "combine-source-map": "^0.8.0",
-        "concat-stream": "^1.6.1",
-        "is-buffer": "^1.1.0",
-        "JSONStream": "^1.0.3",
-        "path-is-absolute": "^1.0.1",
-        "process": "~0.11.0",
-        "through2": "^2.0.0",
-        "undeclared-identifiers": "^1.1.2",
-        "xtend": "^4.0.0"
-      },
-      "bin": {
-        "insert-module-globals": "bin/cmd.js"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-      "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha1-lwN+89UiJNhRY/VZeytj2a/tmBo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-invalid-path": {
-      "version": "0.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
-      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
-      "license": "MIT",
-      "dependencies": {
-        "is-glob": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "license": "MIT"
-    },
-    "node_modules/is-valid-path": {
-      "version": "0.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-valid-path/-/is-valid-path-0.1.1.tgz",
-      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
-      "license": "MIT",
-      "dependencies": {
-        "is-invalid-path": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "license": "MIT"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "license": "MIT"
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "node_modules/json-schema-deref-sync": {
-      "version": "0.13.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
-      "integrity": "sha1-ywi0/0NaSLWhSWUtd1D90HEAmCM=",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^2.1.2",
-        "dag-map": "~1.0.0",
-        "is-valid-path": "^0.1.1",
-        "lodash": "^4.17.13",
-        "md5": "~2.2.0",
-        "memory-cache": "~0.2.0",
-        "traverse": "~0.6.6",
-        "valid-url": "~1.0.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify": {
-      "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "license": "ISC"
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true,
-      "license": "Public Domain",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/JSONStream": {
+  "dependencies": {
+    "JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "dependencies": {
+      "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
       }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/klaw-sync": {
-      "version": "3.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/klaw-sync/-/klaw-sync-3.0.2.tgz",
-      "integrity": "sha1-vzpcpGOvWuwAcgHb6L5wiO8p0Gc=",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
-      }
-    },
-    "node_modules/labeled-stream-splicer": {
-      "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
-      "integrity": "sha1-QqQaFqvNRv0EYwbPTyw1dv/7HCE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "stream-splicer": "^2.0.0"
-      }
-    },
-    "node_modules/lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-      "license": "MIT"
-    },
-    "node_modules/lodash.memoize": {
-      "version": "3.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lognext": {
-      "version": "0.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lognext/-/lognext-0.0.4.tgz",
-      "integrity": "sha1-TF+CFynS0rUgQKtqzMlslh2zkSU=",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.4",
-        "winston": "^2.4.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
-      }
-    },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/mdjavadoc-api": {
-      "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mdjavadoc-api/-/mdjavadoc-api-1.0.4.tgz",
-      "integrity": "sha1-ZMTo+Qj++wY6rslVSjcCfDoW4mo=",
-      "license": "MIT"
-    },
-    "node_modules/memory-cache": {
-      "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo=",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      },
-      "bin": {
-        "miller-rabin": "bin/miller-rabin"
-      }
-    },
-    "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4=",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha1-Ymd0in95lZTePLyM3pHe80lmHO4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha1-HUq3faZLkfX3JInfKSNlY3VLsbI=",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.46.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/module-deps": {
-      "version": "6.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/module-deps/-/module-deps-6.2.3.tgz",
-      "integrity": "sha1-FUkLwCr0tWz2IpnHwXy6Mtcalu4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browser-resolve": "^2.0.0",
-        "cached-path-relative": "^1.0.2",
-        "concat-stream": "~1.6.0",
-        "defined": "^1.0.0",
-        "detective": "^5.2.0",
-        "duplexer2": "^0.1.2",
-        "inherits": "^2.0.1",
-        "JSONStream": "^1.0.3",
-        "parents": "^1.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.4.0",
-        "stream-combiner2": "^1.1.1",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
-      },
-      "bin": {
-        "module-deps": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/module-deps/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/module-deps/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/module-deps/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M=",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha1-slL9a7V/NBybWaWrYajlGnO70iw=",
-      "license": "MIT",
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "license": "MIT"
-    },
-    "node_modules/mustache": {
-      "version": "2.3.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha1-ptTZw/kdEzWauImoEpVPkjCj0MU=",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      },
-      "engines": {
-        "npm": ">=1.4.0"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "license": "MIT",
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha1-yQUh104RJ7ZyZt7TOUrWEWmGUzo=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parents": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/parents/-/parents-1.0.1.tgz",
-      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-platform": "~0.11.15"
-      }
-    },
-    "node_modules/parse-asn1": {
-      "version": "5.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "asn1.js": "^5.2.0",
-        "browserify-aes": "^1.0.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "license": "MIT"
-    },
-    "node_modules/pluralize": {
-      "version": "3.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pluralize/-/pluralize-3.1.0.tgz",
-      "integrity": "sha1-hCE9ChI1YGnaqEBgxVkkJjMWE2g=",
-      "license": "MIT"
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "license": "MIT"
-    },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
-      "license": "MIT"
-    },
-    "node_modules/public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/purecloud-platform-client-v2": {
-      "version": "109.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/purecloud-platform-client-v2/-/purecloud-platform-client-v2-109.0.0.tgz",
-      "integrity": "sha1-8gKvlaDbb6bE5q0PUEnok0zTeUk=",
-      "license": "MIT",
-      "dependencies": {
-        "superagent": "^3.8.3"
-      }
-    },
-    "node_modules/purecloud-platform-client-v2/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purecloud-platform-client-v2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/purecloud-platform-client-v2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/purecloud-platform-client-v2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/purecloud-platform-client-v2/node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/read-only-stream": {
-      "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/read-only-stream/-/read-only-stream-2.0.0.tgz",
-      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/read-only-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/read-only-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/read-only-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "license": "ISC"
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request/-/request-2.88.2.tgz",
-      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
-      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "0.58.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup/-/rollup-0.58.2.tgz",
-      "integrity": "sha1-L+3eqMDAIvPnSzXEjjwhs0M4A84=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "0.0.38",
-        "@types/node": "*"
-      },
-      "bin": {
-        "rollup": "bin/rollup"
-      }
-    },
-    "node_modules/rollup-plugin-json": {
-      "version": "2.3.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup-plugin-json/-/rollup-plugin-json-2.3.1.tgz",
-      "integrity": "sha1-l1nSfzPc0siW3hi2I13xYriO3Xc=",
-      "deprecated": "This module has been deprecated and is no longer maintained. Please use @rollup/plugin-json.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rollup-pluginutils": "^2.0.1"
-      },
-      "peerDependencies": {
-        "rollup": "< 0.59.0"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
-      "dev": true,
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      }
-    },
-    "node_modules/shasum": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shasum/-/shasum-1.0.2.tgz",
-      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-stable-stringify": "~0.0.0",
-        "sha.js": "~2.4.4"
-      }
-    },
-    "node_modules/shasum-object": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shasum-object/-/shasum-object-1.0.0.tgz",
-      "integrity": "sha1-C3t0/1tm7PkDVHVSL6BQkKxH4p4=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "fast-safe-stringify": "^2.0.7"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha1-Z6fQLHbJ2iT5nSCAj8re0ODgS+I=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stream-browserify": {
-      "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stream-browserify/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/stream-combiner2": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-combiner2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stream-combiner2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stream-combiner2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/stream-http": {
-      "version": "3.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-http/-/stream-http-3.1.1.tgz",
-      "integrity": "sha1-A3CoAXz40FC5qFVK/mCPBD6v9WQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/stream-splicer": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-splicer/-/stream-splicer-2.0.1.tgz",
-      "integrity": "sha1-CxO37itax+BgmnRj2DiZWJo2P80=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-splicer/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stream-splicer/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stream-splicer/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/subarg": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/subarg/-/subarg-1.0.0.tgz",
-      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.1.0"
-      }
-    },
-    "node_modules/superagent": {
-      "version": "6.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha1-CfCIB7xBEI7xZM+0vik869SA9KY=",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
-        "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">= 7.0.0"
-      }
-    },
-    "node_modules/superagent-bluebird-promise": {
-      "version": "4.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent-bluebird-promise/-/superagent-bluebird-promise-4.2.0.tgz",
-      "integrity": "sha1-C2pocsyDA3HLn0Fy3QUQdRq9FrI=",
-      "license": "MIT",
-      "peerDependencies": {
-        "bluebird": "3.x",
-        "superagent": ">=1.x"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/syntax-error": {
-      "version": "1.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha1-LZ1P9cBkrLcRWUo+O5UFStUdkHw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.2.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/tar-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/tar-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/timers-browserify": {
-      "version": "1.4.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "dev": true,
-      "dependencies": {
-        "process": "~0.11.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
-      "license": "MIT"
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.6.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "license": "MIT"
-    },
-    "node_modules/tty-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tunnel": {
-      "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tunnel/-/tunnel-0.0.2.tgz",
-      "integrity": "sha1-8jvNi3p7ioZCYbIIT2b5MZM5YzQ=",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "license": "Unlicense"
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/umd": {
-      "version": "3.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha1-qp/mU8QrkJdnhInAEACstp8LJs8=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "umd": "bin/cli.js"
-      }
-    },
-    "node_modules/undeclared-identifiers": {
-      "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
-      "integrity": "sha1-klTB03vawKwrUt5LZyJ5LSqR4w8=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn-node": "^1.3.0",
-        "dash-ast": "^1.0.0",
-        "get-assigned-identifiers": "^1.2.0",
-        "simple-concat": "^1.0.0",
-        "xtend": "^4.0.1"
-      },
-      "bin": {
-        "undeclared-identifiers": "bin.js"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/urlencode": {
-      "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/urlencode/-/urlencode-1.1.0.tgz",
-      "integrity": "sha1-HyuibwE8hfATP3o61v8nMK33y7c=",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "~0.4.11"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util/-/util-0.10.4.tgz",
-      "integrity": "sha1-OqASW/5mikZy3liFfTrOJ+y3aQE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "license": "MIT"
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/vm-browserify": {
-      "version": "1.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/wget": {
-      "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/wget/-/wget-0.0.1.tgz",
-      "integrity": "sha1-i7ga8LjmC13yYtPIHlc34fSTHlM=",
-      "dependencies": {
-        "tunnel": "0.0.2"
-      },
-      "bin": {
-        "nwget": "bin/nwget.js"
-      },
-      "engines": {
-        "node": ">= 0.6.18"
-      }
-    },
-    "node_modules/winston": {
-      "version": "2.4.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/winston/-/winston-2.4.5.tgz",
-      "integrity": "sha1-8uQx1WFUxOp2VUX8EAO9NAyVtZo=",
-      "license": "MIT",
-      "dependencies": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/winston/node_modules/async": {
-      "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-      "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-      "license": "ISC"
-    },
-    "node_modules/yamljs": {
-      "version": "0.2.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/yamljs/-/yamljs-0.2.10.tgz",
-      "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "json2yaml": "bin/json2yaml",
-        "yaml2json": "bin/yaml2json"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/zip-stream/-/zip-stream-1.2.0.tgz",
-      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^1.3.0",
-        "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "license": "MIT"
-    },
-    "node_modules/zip-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@types/estree": {
-      "version": "0.0.38",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/@types/estree/-/estree-0.0.38.tgz",
-      "integrity": "sha1-wb5AqpM3I8YIggqZo3OhbSFaHKI=",
-      "dev": true,
-      "peer": true
-    },
-    "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha1-o92NpOuEqZbDbjMd+Y2Cq9drUW4=",
-      "dev": true,
-      "peer": true
     },
     "acorn": {
       "version": "7.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha1-EUyV1kU55T3t4j3oudlt98euKvg=",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
       "dev": true,
       "requires": {
         "acorn": "^7.0.0",
@@ -3659,14 +33,14 @@
     },
     "acorn-walk": {
       "version": "7.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3676,7 +50,7 @@
     },
     "archiver": {
       "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/archiver/-/archiver-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "requires": {
         "archiver-utils": "^1.3.0",
@@ -3688,40 +62,11 @@
         "tar-stream": "^1.5.0",
         "walkdir": "^0.0.11",
         "zip-stream": "^1.1.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "archiver-utils": {
       "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "requires": {
         "glob": "^7.0.0",
@@ -3730,57 +75,28 @@
         "lodash": "^4.8.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
       "version": "5.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -3791,16 +107,16 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -3809,13 +125,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -3826,45 +142,45 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/async/-/async-2.6.3.tgz",
-      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
         "lodash": "^4.17.14"
       }
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.11.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.5.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -3872,57 +188,28 @@
     },
     "bl": {
       "version": "1.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "5.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3930,19 +217,19 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
       "version": "6.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browser-pack/-/browser-pack-6.1.0.tgz",
-      "integrity": "sha1-w0uhDQuc4WK1ryJ8cTHJLC7NV3Q=",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
+        "JSONStream": "^1.0.3",
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
-        "JSONStream": "^1.0.3",
         "safe-buffer": "^5.1.1",
         "through2": "^2.0.0",
         "umd": "^3.0.0"
@@ -3950,8 +237,8 @@
     },
     "browser-resolve": {
       "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browser-resolve/-/browser-resolve-2.0.0.tgz",
-      "integrity": "sha1-mbcwTLOS+Nc9unQbstfaKMbXhCs=",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
       "dev": true,
       "requires": {
         "resolve": "^1.17.0"
@@ -3959,10 +246,11 @@
     },
     "browserify": {
       "version": "16.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify/-/browserify-16.5.2.tgz",
-      "integrity": "sha1-2SaDXpKA+l/Vf1vDAfLvJKly3f4=",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+      "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
       "dev": true,
       "requires": {
+        "JSONStream": "^1.0.3",
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
         "browser-resolve": "^2.0.0",
@@ -3984,7 +272,6 @@
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
         "insert-module-globals": "^7.0.0",
-        "JSONStream": "^1.0.3",
         "labeled-stream-splicer": "^2.0.0",
         "mkdirp-classic": "^0.5.2",
         "module-deps": "^6.2.3",
@@ -4013,42 +300,28 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -4061,8 +334,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -4072,8 +345,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4084,8 +357,8 @@
     },
     "browserify-rsa": {
       "version": "4.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-      "integrity": "sha1-sv0Gtbda4pf3zi3GUfkY9b4VjI0=",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "dev": true,
       "requires": {
         "bn.js": "^5.0.0",
@@ -4094,8 +367,8 @@
     },
     "browserify-sign": {
       "version": "4.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
@@ -4107,30 +380,49 @@
         "parse-asn1": "^5.1.5",
         "readable-stream": "^3.6.0",
         "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
       }
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha1-3Vf6DxCaxZxgJHkETcp7iz0LcdY=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -4138,47 +430,47 @@
     },
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA="
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "cached-path-relative": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha1-oT30GW0md2IgzDNW6xR6Utuixts=",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
     "call-bind": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4186,18 +478,18 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4206,17 +498,17 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combine-source-map": {
       "version": "0.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
@@ -4228,189 +520,99 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compress-commons": {
       "version": "1.2.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/compress-commons/-/compress-commons-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "requires": {
         "buffer-crc32": "^0.2.1",
         "crc32-stream": "^2.0.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
     "cookiejar": {
       "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
       "version": "3.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "requires": {
         "buffer": "^5.1.0"
       }
     },
     "crc32-stream": {
       "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "create-ecdh": {
       "version": "4.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4419,16 +621,16 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4440,8 +642,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4454,13 +656,13 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -4478,23 +680,23 @@
     },
     "cycle": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/cycle/-/cycle-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "dag-map": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dag-map/-/dag-map-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
       "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc="
     },
     "dash-ast": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dash-ast/-/dash-ast-1.0.0.tgz",
-      "integrity": "sha1-EgKbpfsviqbwqGF5WyPBtLbCfTc=",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4502,32 +704,32 @@
     },
     "dateformat": {
       "version": "3.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "3.2.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "requires": {
         "ms": "^2.1.1"
       }
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "deps-sort": {
       "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/deps-sort/-/deps-sort-2.0.1.tgz",
-      "integrity": "sha1-nf3IdtK87DOGtoKaxSFizan6II0=",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
@@ -4538,8 +740,8 @@
     },
     "des.js": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4548,8 +750,8 @@
     },
     "detective": {
       "version": "5.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/detective/-/detective-5.2.0.tgz",
-      "integrity": "sha1-/rKnfoW5BOzepFmtiXzJCpm9Kns=",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "dev": true,
       "requires": {
         "acorn-node": "^1.6.1",
@@ -4559,8 +761,8 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4570,67 +772,35 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "dot": {
       "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/dot/-/dot-1.1.3.tgz",
-      "integrity": "sha1-NRNg4Ap0i86aH48nwAw5Sn5OHp8="
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz",
+      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg=="
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -4639,8 +809,8 @@
     },
     "elliptic": {
       "version": "6.5.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
@@ -4654,36 +824,36 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "estree-walker": {
       "version": "0.6.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
     "events": {
       "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/events/-/events-2.1.0.tgz",
-      "integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U=",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -4692,43 +862,43 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/eyes/-/eyes-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M="
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -4737,18 +907,18 @@
     },
     "formidable": {
       "version": "1.2.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha1-v2muopcpgmdfAIZTQrmCmG9rjdk="
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "5.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4757,24 +927,24 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-assigned-identifiers": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha1-bb9BHeZIy6+NkWnrsNLVdhkeL/E=",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
       "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4783,7 +953,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4791,22 +961,41 @@
     },
     "github-api-promise": {
       "version": "1.13.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/github-api-promise/-/github-api-promise-1.13.4.tgz",
-      "integrity": "sha1-/gqH6UF4vyavpBM0C2e4KxVeL3E=",
+      "resolved": "https://registry.npmjs.org/github-api-promise/-/github-api-promise-1.13.4.tgz",
+      "integrity": "sha512-UF2n2XO/TQj+yQMwTE86EnBdTtl3TE63ij5auDIJ8TeJV74IsTlK30KI5uMXcPeOKP5lRroZUQrJBklLJAplqw==",
       "requires": {
         "bluebird": "^3.5.1",
         "lodash": "^4.17.10",
         "lognext": "0.0.4",
         "q": "^1.5.1",
-        "superagent": "^6.0.1",
+        "superagent": "^3.8.3",
         "superagent-bluebird-promise": "^4.2.0",
         "urlencode": "^1.1.0"
+      },
+      "dependencies": {
+        "superagent": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
+          }
+        }
       }
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4818,18 +1007,18 @@
     },
     "graceful-fs": {
       "version": "4.2.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4="
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -4837,32 +1026,51 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-symbols": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "hash-base": {
       "version": "3.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
         "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -4871,7 +1079,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -4882,13 +1090,13 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -4898,26 +1106,26 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
       "version": "1.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -4926,12 +1134,12 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inline-source-map": {
       "version": "0.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
@@ -4940,15 +1148,15 @@
     },
     "insert-module-globals": {
       "version": "7.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
-      "integrity": "sha1-1eMxhRgaTh8zsV978QDukYkNXLM=",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
       "dev": true,
       "requires": {
+        "JSONStream": "^1.0.3",
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
         "concat-stream": "^1.6.1",
         "is-buffer": "^1.1.0",
-        "JSONStream": "^1.0.3",
         "path-is-absolute": "^1.0.1",
         "process": "~0.11.0",
         "through2": "^2.0.0",
@@ -4958,13 +1166,13 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-core-module": {
       "version": "2.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha1-lwN+89UiJNhRY/VZeytj2a/tmBo=",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4972,12 +1180,12 @@
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
         "is-extglob": "^1.0.0"
@@ -4985,7 +1193,7 @@
     },
     "is-invalid-path": {
       "version": "0.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
       "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
       "requires": {
         "is-glob": "^2.0.0"
@@ -4993,12 +1201,12 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-valid-path": {
       "version": "0.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
       "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
       "requires": {
         "is-invalid-path": "^0.1.0"
@@ -5006,28 +1214,28 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-deref-sync": {
       "version": "0.13.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
-      "integrity": "sha1-ywi0/0NaSLWhSWUtd1D90HEAmCM=",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
+      "integrity": "sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==",
       "requires": {
         "clone": "^2.1.2",
         "dag-map": "~1.0.0",
@@ -5041,12 +1249,12 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
@@ -5055,12 +1263,12 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -5068,29 +1276,19 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -5101,16 +1299,16 @@
     },
     "klaw-sync": {
       "version": "3.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/klaw-sync/-/klaw-sync-3.0.2.tgz",
-      "integrity": "sha1-vzpcpGOvWuwAcgHb6L5wiO8p0Gc=",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-3.0.2.tgz",
+      "integrity": "sha512-32bw9y2nKrnpX2LsJnDTBO2TSdOKPbXfQAWl7Lupcc3D0iKkzI/sQDEw1GjkOuTqZEhe+bVxKSlhSRLxyeytcw==",
       "requires": {
         "graceful-fs": "^4.1.11"
       }
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
-      "integrity": "sha1-QqQaFqvNRv0EYwbPTyw1dv/7HCE=",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5119,56 +1317,27 @@
     },
     "lazystream": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lazystream/-/lazystream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
         "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "lodash": {
       "version": "4.17.21",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
     "lognext": {
       "version": "0.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lognext/-/lognext-0.0.4.tgz",
-      "integrity": "sha1-TF+CFynS0rUgQKtqzMlslh2zkSU=",
+      "resolved": "https://registry.npmjs.org/lognext/-/lognext-0.0.4.tgz",
+      "integrity": "sha512-xizlpCVMSHiYOgY8JCJVQyk1TxX3nVMgKn4nTPbgmKyM+i8QYBXZ5NIVUugQuj6wWFXX0c6kFE9lEtG5RiM/2Q==",
       "requires": {
         "lodash": "^4.17.4",
         "winston": "^2.4.0"
@@ -5176,15 +1345,15 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
       }
     },
     "md5": {
       "version": "2.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/md5/-/md5-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
         "charenc": "~0.0.1",
@@ -5194,8 +1363,8 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -5205,23 +1374,23 @@
     },
     "mdjavadoc-api": {
       "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mdjavadoc-api/-/mdjavadoc-api-1.0.4.tgz",
-      "integrity": "sha1-ZMTo+Qj++wY6rslVSjcCfDoW4mo="
+      "resolved": "https://registry.npmjs.org/mdjavadoc-api/-/mdjavadoc-api-1.0.4.tgz",
+      "integrity": "sha512-0Sm2cOYnSisI4Jvw1x+W8O8rvLdfBsQpzh9kecfxuECTVVVYtTOyOMPqBvmJYuKpieq5+p43bCwEhJMZq8MEaw=="
     },
     "memory-cache": {
       "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/memory-cache/-/memory-cache-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -5230,68 +1399,69 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "mime": {
-      "version": "2.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.46.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha1-Ymd0in95lZTePLyM3pHe80lmHO4="
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
       "version": "2.1.29",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha1-HUq3faZLkfX3JInfKSNlY3VLsbI=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
         "mime-db": "1.46.0"
       }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "module-deps": {
       "version": "6.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/module-deps/-/module-deps-6.2.3.tgz",
-      "integrity": "sha1-FUkLwCr0tWz2IpnHwXy6Mtcalu4=",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+      "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
       "dev": true,
       "requires": {
+        "JSONStream": "^1.0.3",
         "browser-resolve": "^2.0.0",
         "cached-path-relative": "^1.0.2",
         "concat-stream": "~1.6.0",
@@ -5299,7 +1469,6 @@
         "detective": "^5.2.0",
         "duplexer2": "^0.1.2",
         "inherits": "^2.0.1",
-        "JSONStream": "^1.0.3",
         "parents": "^1.0.0",
         "readable-stream": "^2.0.2",
         "resolve": "^1.4.0",
@@ -5307,66 +1476,34 @@
         "subarg": "^1.0.0",
         "through2": "^2.0.0",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "moment": {
       "version": "2.29.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.33",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha1-slL9a7V/NBybWaWrYajlGnO70iw=",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
       "requires": {
         "moment": ">= 2.9.0"
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mustache": {
       "version": "2.3.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha1-ptTZw/kdEzWauImoEpVPkjCj0MU="
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -5374,23 +1511,23 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
       "version": "1.9.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha1-yQUh104RJ7ZyZt7TOUrWEWmGUzo="
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -5398,19 +1535,19 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parents": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/parents/-/parents-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
@@ -5419,8 +1556,8 @@
     },
     "parse-asn1": {
       "version": "5.1.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "dev": true,
       "requires": {
         "asn1.js": "^5.2.0",
@@ -5432,31 +1569,31 @@
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-platform": {
       "version": "0.11.15",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-platform/-/path-platform-0.11.15.tgz",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "pbkdf2": {
       "version": "3.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -5468,34 +1605,34 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pluralize": {
       "version": "3.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/pluralize/-/pluralize-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-3.1.0.tgz",
       "integrity": "sha1-hCE9ChI1YGnaqEBgxVkkJjMWE2g="
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -5508,62 +1645,29 @@
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
       }
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "purecloud-platform-client-v2": {
       "version": "109.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/purecloud-platform-client-v2/-/purecloud-platform-client-v2-109.0.0.tgz",
-      "integrity": "sha1-8gKvlaDbb6bE5q0PUEnok0zTeUk=",
+      "resolved": "https://registry.npmjs.org/purecloud-platform-client-v2/-/purecloud-platform-client-v2-109.0.0.tgz",
+      "integrity": "sha512-ImQst0LTnzI4WqF9n3N9IqwrG2aUnqtWn7FsHxPK/4lAPaIYb/EBw3snmN2xeOQ2URt8D0ueL4r+izf6zGnJeA==",
       "requires": {
         "superagent": "^3.8.3"
       },
       "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
         "superagent": {
           "version": "3.8.3",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent/-/superagent-3.8.3.tgz",
-          "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.1.0",
@@ -5581,30 +1685,33 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -5612,8 +1719,8 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -5622,64 +1729,36 @@
     },
     "read-only-stream": {
       "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request/-/request-2.88.2.tgz",
-      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5701,12 +1780,29 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "request-promise": {
       "version": "4.2.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "request-promise-core": "1.1.4",
@@ -5716,16 +1812,16 @@
     },
     "request-promise-core": {
       "version": "1.1.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
         "lodash": "^4.17.19"
       }
     },
     "resolve": {
       "version": "1.20.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
@@ -5734,29 +1830,18 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
     },
-    "rollup": {
-      "version": "0.58.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup/-/rollup-0.58.2.tgz",
-      "integrity": "sha1-L+3eqMDAIvPnSzXEjjwhs0M4A84=",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/estree": "0.0.38",
-        "@types/node": "*"
-      }
-    },
     "rollup-plugin-json": {
       "version": "2.3.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup-plugin-json/-/rollup-plugin-json-2.3.1.tgz",
-      "integrity": "sha1-l1nSfzPc0siW3hi2I13xYriO3Xc=",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-2.3.1.tgz",
+      "integrity": "sha512-alQQQVPo2z9pl6LSK8QqyDlWwCH5KeE8YxgQv7fa/SeTxz+gQe36jBjcha7hQW68MrVh9Ms71EQaMZDAG3w2yw==",
       "dev": true,
       "requires": {
         "rollup-pluginutils": "^2.0.1"
@@ -5764,32 +1849,32 @@
     },
     "rollup-pluginutils": {
       "version": "2.8.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5798,7 +1883,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
@@ -5808,8 +1893,8 @@
     },
     "shasum-object": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shasum-object/-/shasum-object-1.0.0.tgz",
-      "integrity": "sha1-C3t0/1tm7PkDVHVSL6BQkKxH4p4=",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+      "integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
       "dev": true,
       "requires": {
         "fast-safe-stringify": "^2.0.7"
@@ -5817,14 +1902,14 @@
     },
     "shell-quote": {
       "version": "1.7.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha1-Z6fQLHbJ2iT5nSCAj8re0ODgS+I=",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -5833,25 +1918,25 @@
     },
     "simple-concat": {
       "version": "1.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -5866,163 +1951,80 @@
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "stream-http": {
       "version": "3.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-http/-/stream-http-3.1.1.tgz",
-      "integrity": "sha1-A3CoAXz40FC5qFVK/mCPBD6v9WQ=",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+      "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
-      }
-    },
-    "stream-splicer": {
-      "version": "2.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/stream-splicer/-/stream-splicer-2.0.1.tgz",
-      "integrity": "sha1-CxO37itax+BgmnRj2DiZWJo2P80=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+    "stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
       "requires": {
-        "safe-buffer": "~5.2.0"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "subarg": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/subarg/-/subarg-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
@@ -6031,8 +2033,8 @@
     },
     "superagent": {
       "version": "6.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha1-CfCIB7xBEI7xZM+0vik869SA9KY=",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -6049,34 +2051,46 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
         },
         "form-data": {
           "version": "3.0.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
         },
-        "qs": {
-          "version": "6.10.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
-            "side-channel": "^1.0.4"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -6085,14 +2099,13 @@
     },
     "superagent-bluebird-promise": {
       "version": "4.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/superagent-bluebird-promise/-/superagent-bluebird-promise-4.2.0.tgz",
-      "integrity": "sha1-C2pocsyDA3HLn0Fy3QUQdRq9FrI=",
-      "requires": {}
+      "resolved": "https://registry.npmjs.org/superagent-bluebird-promise/-/superagent-bluebird-promise-4.2.0.tgz",
+      "integrity": "sha1-C2pocsyDA3HLn0Fy3QUQdRq9FrI="
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha1-LZ1P9cBkrLcRWUo+O5UFStUdkHw=",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
         "acorn-node": "^1.2.0"
@@ -6100,8 +2113,8 @@
     },
     "tar-stream": {
       "version": "1.6.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -6110,88 +2123,27 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -6200,44 +2152,37 @@
     },
     "to-buffer": {
       "version": "1.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA="
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
-        }
       }
     },
     "traverse": {
       "version": "0.6.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/traverse/-/traverse-0.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "tty-browserify": {
       "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE=",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
     },
     "tunnel": {
       "version": "0.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tunnel/-/tunnel-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.2.tgz",
       "integrity": "sha1-8jvNi3p7ioZCYbIIT2b5MZM5YzQ="
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -6245,25 +2190,25 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "umd": {
       "version": "3.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha1-qp/mU8QrkJdnhInAEACstp8LJs8=",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
     },
     "undeclared-identifiers": {
       "version": "1.1.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
-      "integrity": "sha1-klTB03vawKwrUt5LZyJ5LSqR4w8=",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
       "dev": true,
       "requires": {
         "acorn-node": "^1.3.0",
@@ -6275,27 +2220,20 @@
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
-        }
       }
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -6305,7 +2243,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -6313,7 +2251,7 @@
     },
     "urlencode": {
       "version": "1.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/urlencode/-/urlencode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urlencode/-/urlencode-1.1.0.tgz",
       "integrity": "sha1-HyuibwE8hfATP3o61v8nMK33y7c=",
       "requires": {
         "iconv-lite": "~0.4.11"
@@ -6321,8 +2259,8 @@
     },
     "util": {
       "version": "0.10.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util/-/util-0.10.4.tgz",
-      "integrity": "sha1-OqASW/5mikZy3liFfTrOJ+y3aQE=",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -6330,7 +2268,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -6338,22 +2276,22 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "valid-url": {
       "version": "1.0.9",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/valid-url/-/valid-url-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -6363,18 +2301,18 @@
     },
     "vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
     "walkdir": {
       "version": "0.0.11",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/walkdir/-/walkdir-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
     },
     "wget": {
       "version": "0.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/wget/-/wget-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wget/-/wget-0.0.1.tgz",
       "integrity": "sha1-i7ga8LjmC13yYtPIHlc34fSTHlM=",
       "requires": {
         "tunnel": "0.0.2"
@@ -6382,8 +2320,8 @@
     },
     "winston": {
       "version": "2.4.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/winston/-/winston-2.4.5.tgz",
-      "integrity": "sha1-8uQx1WFUxOp2VUX8EAO9NAyVtZo=",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -6395,29 +2333,29 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yamljs": {
       "version": "0.2.10",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/yamljs/-/yamljs-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",
       "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
       "requires": {
         "argparse": "^1.0.7",
@@ -6426,42 +2364,13 @@
     },
     "zip-stream": {
       "version": "1.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/zip-stream/-/zip-stream-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "requires": {
         "archiver-utils": "^1.3.0",
         "compress-commons": "^1.2.0",
         "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
@ronanwatkins I deleted the shrinkwrap file and regenerated it installing from the public npm registry so there's not a dependency on artifactory. When you switched to the shrinkwrap file, was there a specific version you were setting for anything? I just deleted the file and ran `npm i` then `npm shrinkwrap` so any manual edits you might have made got removed. The diff is too gnarly to parse to figure out if there were manual edits.