### PR TITLE
Upgrading to github-api-promise version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dateformat": "^3.0.3",
     "dot": "^1.1.3",
     "fs-extra": "^5.0.0",
-    "github-api-promise": "^1.12.2",
+    "github-api-promise": "^1.13.5",
     "json-schema-deref-sync": "^0.13.0",
     "klaw-sync": "^3.0.2",
     "lodash": "^4.17.19",


### PR DESCRIPTION
Upgrading to github-api-promise version to 1.13.5 to include required user-agent header changes