### PR TITLE
Use SetBody on retryablerequest to ensure body can be resent

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -118,14 +118,14 @@ func (c *APIClient) CallAPI(path string, method string,
 		// }
 
 		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		request.Body = ioutil.NopCloser(strings.NewReader(formParams.Encode()))
+		request.SetBody(ioutil.NopCloser(strings.NewReader(formParams.Encode())))
 	}
 
 	// Set post body
 	if postBody != nil {
 		request.Header.Set("Content-Type", "application/json")
 		j, _ := json.Marshal(postBody)
-		request.Body = ioutil.NopCloser(bytes.NewReader(j))
+		request.SetBody(ioutil.NopCloser(bytes.NewReader(j)))
 	}
 
 	// Set provided headers


### PR DESCRIPTION
Using the SetBody method is required to ensure the the retryablerequest library is able to rewind the body for retries. Otherwise it sends an empty body in the first retry. https://github.com/hashicorp/go-retryablehttp/blob/v0.7.0/client.go#L126