### PR TITLE
Updating go SDK Makefile and config.json

### DIFF
--- a/resources/sdk/purecloudgo/config.json
+++ b/resources/sdk/purecloudgo/config.json
@@ -62,29 +62,13 @@
       "preRunScripts": [
         {
           "type": "command",
-          "command": "rm",
-      		"cwd": "${SDK_REPO}",
-      		"args":[ "-rf", "./platformclientv2" ],
-          "failOnError": true
-        }
-      ],
-      "postRunScripts": [
-        {
-          "type": "node",
-          "path": "postbuild-postrun.js",
-          "args": [
-            "${SDK_REPO}"
-          ],
-          "failOnError": true
-        },
-        {
-          "type": "command",
           "command": "make",
       		"cwd": "${SDK_REPO}",
       		"args":[ "build", "test" ],
           "failOnError": true
         }
-      ]
+      ],
+      "postRunScripts": []
     }
   }
 }

--- a/resources/sdk/purecloudgo/templates/Makefile.mustache
+++ b/resources/sdk/purecloudgo/templates/Makefile.mustache
@@ -1,7 +1,7 @@
-PACKAGE_NAME = platformclientv2
+PACKAGE_NAME = {{packageName}}
 
 build:
-	cd ${PACKAGE_NAME}; go build -o ../bin/${PACKAGE_NAME}
+	go build ./${PACKAGE_NAME}
 
 test:
-	cd ${PACKAGE_NAME}; go test -v -failfast
+	go test ./${PACKAGE_NAME} -v -failfast


### PR DESCRIPTION
Required because the go SDK build had scripts running in the wrong order resulting in old API files being included in the build.