### PR TITLE
More changes to fix the go build

### DIFF
--- a/resources/sdk/purecloudgo/config.json
+++ b/resources/sdk/purecloudgo/config.json
@@ -53,7 +53,15 @@
     },
     "build": {
       "preRunScripts": [],
-      "compileScripts": [],
+      "compileScripts": [
+        {
+          "type": "command",
+          "command": "make",
+      		"cwd": "${SDK_REPO}/build",
+      		"args":[ "build", "test" ],
+          "failOnError": true
+        }
+      ],
       "postRunScripts": []
     },
     "postbuild": {
@@ -67,15 +75,7 @@
           "failOnError": true
         }
       ],
-      "postRunScripts": [
-        {
-          "type": "command",
-          "command": "make",
-      		"cwd": "${SDK_REPO}",
-      		"args":[ "build", "test" ],
-          "failOnError": true
-        }
-      ]
+      "postRunScripts": []
     }
   }
 }

--- a/resources/sdk/purecloudgo/scripts/postbuild-postrun.js
+++ b/resources/sdk/purecloudgo/scripts/postbuild-postrun.js
@@ -11,7 +11,7 @@ try {
 	const dir = fs.opendirSync(repoPath);
 	let dirent;
 	while ((dirent = dir.readSync()) !== null) {
-		if (dirent.isDirectory() && dirent.name !== 'build')
+		if (dirent.isDirectory() && dirent.name !== 'build' && !dirent.name.startsWith("."))
 			fs.removeSync(path.join(repoPath, dirent.name))
 	}
 	dir.closeSync();


### PR DESCRIPTION
Scripts had been running in the wrong order and postbuild-postrun.js was deleting a '.git' directory causing problems