### PR TITLE
Adding major version to the Go SDK module name to comply with convention

### DIFF
--- a/resources/sdk/purecloudgo/scripts/prebuild-postrun.js
+++ b/resources/sdk/purecloudgo/scripts/prebuild-postrun.js
@@ -10,6 +10,7 @@ try {
 		basePath: 'https://api.mypurecloud.com',
 		packageName: packageName || 'platform-client',
 		packageVersion: version.displayFull,
+		majorVersion: `v${version.major}`,
 		httpUserAgent: 'PureCloud SDK'
 	};
 

--- a/resources/sdk/purecloudgo/templates/README.mustache
+++ b/resources/sdk/purecloudgo/templates/README.mustache
@@ -18,7 +18,7 @@ Some macOS users encounter the error "argument list too long" when building or i
 Retrieve the package from https://github.com/MyPureCloud/platform-client-sdk-go using `go get`:
 
 ```go
-go get github.com/mypurecloud/platform-client-sdk-go/platformclientv2
+go get github.com/mypurecloud/platform-client-sdk-go/{{majorVersion}}/platformclientv2
 ```
 
 ## Using the SDK
@@ -27,7 +27,7 @@ go get github.com/mypurecloud/platform-client-sdk-go/platformclientv2
 
 ```go
 import (
-	"github.com/MyPureCloud/platform-client-sdk-go/platformclientv2"
+	"github.com/MyPureCloud/platform-client-sdk-go/{{majorVersion}}/platformclientv2"
 )
 ```
 

--- a/resources/sdk/purecloudgo/templates/go.mod.mustache
+++ b/resources/sdk/purecloudgo/templates/go.mod.mustache
@@ -1,4 +1,4 @@
-module github.com/mypurecloud/platform-client-sdk-go
+module github.com/mypurecloud/platform-client-sdk-go/{{majorVersion}}
 
 go 1.15
 


### PR DESCRIPTION
Related swagger-codegen PR: https://github.com/purecloudlabs/swagger-codegen/pull/36