### PR TITLE
Serialize error response details as an array of objects

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiresponse.mustache
+++ b/resources/sdk/purecloudgo/templates/apiresponse.mustache
@@ -40,6 +40,13 @@ func (r *APIResponse) SetError(err *APIError) {
 	r.ErrorMessage = fmt.Sprintf("API Error: %v - %v (%v)", r.StatusCode, err.Message, r.CorrelationID)
 }
 
+type APIErrorDetail struct {
+	ErrorCode  string `json:"errorCode,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	EntityId   string `json:"entityId,omitempty"`
+	EntityName string `json:"entityName,omitempty"`
+}
+
 // APIError is the standard error body from the API
 type APIError struct {
 	Status            int                    `json:"status,omitempty"`
@@ -48,7 +55,7 @@ type APIError struct {
 	MessageParams     map[string]interface{} `json:"messageParams,omitempty"`
 	Code              string                 `json:"code,omitempty"`
 	ContextID         string                 `json:"contextId,omitempty"`
-	Details           []string               `json:"details,omitempty"`
+	Details           []APIErrorDetail       `json:"details,omitempty"`
 }
 
 // String returns the JSON serialized object

--- a/resources/sdk/purecloudgo/templates/apiresponse.mustache
+++ b/resources/sdk/purecloudgo/templates/apiresponse.mustache
@@ -40,13 +40,6 @@ func (r *APIResponse) SetError(err *APIError) {
 	r.ErrorMessage = fmt.Sprintf("API Error: %v - %v (%v)", r.StatusCode, err.Message, r.CorrelationID)
 }
 
-type APIErrorDetail struct {
-	ErrorCode  string `json:"errorCode,omitempty"`
-	FieldName  string `json:"fieldName,omitempty"`
-	EntityId   string `json:"entityId,omitempty"`
-	EntityName string `json:"entityName,omitempty"`
-}
-
 // APIError is the standard error body from the API
 type APIError struct {
 	Status            int                    `json:"status,omitempty"`
@@ -55,7 +48,7 @@ type APIError struct {
 	MessageParams     map[string]interface{} `json:"messageParams,omitempty"`
 	Code              string                 `json:"code,omitempty"`
 	ContextID         string                 `json:"contextId,omitempty"`
-	Details           []APIErrorDetail       `json:"details,omitempty"`
+	Details           []Detail               `json:"details,omitempty"`
 }
 
 // String returns the JSON serialized object


### PR DESCRIPTION
The Go SDK is returning JSON serialization errors when details are included in an error response.