### PR TITLE
Read the request body from the retryablehttp.Request for tracing

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -143,11 +143,7 @@ func (c *APIClient) CallAPI(path string, method string,
 		}
 	}
 
-	var requestBody []byte
-	if request.Body != nil {
-		requestBody, _ = ioutil.ReadAll(request.Body)
-	}
-	request.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+	requestBody, _ := request.BodyBytes()
 
 	// Execute request
 	res, err := c.client.Do(&request)


### PR DESCRIPTION
The retryablehttp.Request.Body variable does not contain the actual body until the request is made, so all debug traces are not showing the body. In order to read the body beforehand, the BodyBytes() method should be called instead. If there is no body, it returns null. https://pkg.go.dev/github.com/hashicorp/go-retryablehttp#Request.BodyBytes