### PR TITLE
Adding the ability to override config values with env vars and flags

### DIFF
--- a/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
@@ -14,37 +14,37 @@ import (
 )
 
 func constructConfig(profileName string, environment string, clientID string, clientSecret string) config.Configuration {
-	config := &mocks.MockClientConfig{}
+	c := &mocks.MockClientConfig{}
 
-	config.ProfileNameFunc = func() string {
+	c.ProfileNameFunc = func() string {
 		return profileName
 	}
 
-	config.EnvironmentFunc = func() string {
-		return environment
+	c.EnvironmentFunc = func() string {
+		return config.MapEnvironment(environment)
 	}
 
-	config.LogFilePathFunc = func() string {
+	c.LogFilePathFunc = func() string {
 		return ""
 	}
 
-	config.LoggingEnabledFunc = func() bool {
+	c.LoggingEnabledFunc = func() bool {
 		return false
 	}
 
-	config.ClientIDFunc = func() string {
+	c.ClientIDFunc = func() string {
 		return clientID
 	}
 
-	config.ClientSecretFunc = func() string {
+	c.ClientSecretFunc = func() string {
 		return clientSecret
 	}
 
-	config.OAuthTokenDataFunc = func() string {
+	c.OAuthTokenDataFunc = func() string {
 		return ""
 	}
 
-	return config
+	return c
 }
 
 func requestUserInput() config.Configuration {

--- a/resources/sdk/clisdkclient/templates/README.mustache
+++ b/resources/sdk/clisdkclient/templates/README.mustache
@@ -17,7 +17,10 @@ This CLI focuses mainly on exposing the following operations:
 The [Developer Center](https://developer.mypurecloud.com/api/rest/command-line-interface/) contains installation instructions for supported operating systems.
 
 # Setup and Configuration
+
 All access to Genesys Cloud is provided via OAuth client credentials.  Security is enforced via the OAuth client credentials.
+
+If you are using the CLI in a pipeline or don't wish to set up a config file, see [environment variables](#environment-variables) and [parameter overrides](#parameter-overrides).  
 
 To setup and configure your gc CLI run `gc profiles new` command and answer the questions.  If everything works correctly you should have a file created in your home directory called .gc/config.toml.  If for some reason you have problems with the `gc profiles new` command, you can manually create the config file by following the steps below.
 
@@ -37,6 +40,26 @@ client_secret="OAUTH CLIENT SECRET"
 ```
 
 **Note:** You can setup up multiple profiles.  The default profile is what will be used by the CLI by default.  You can use a different profile by passing in a `-p=profile_name` flag on the CLI.
+
+## Environment variables
+
+The following environment variables can be used as overrides or alternatives to their corresponding config file values
+
+```
+GC_ENVIRONMENT
+GC_CLIENT_ID
+GC_CLIENT_SECRET
+```
+
+## Parameter overrides
+
+The following flags can be used as overrides or alternatives to their corresponding config file values
+
+```
+--environment
+--clientid
+--clientsecret
+```
 
 # Using the CLI
 The CLI follows standard POSIX command name and command flag parameter styles.  To see all of the available objects you can issue a `gc` command.  To see all the sub-commands under a particular entity (eg. users) type `gc <<subcommand>>`.  For example to see all of the users in the org you can type `gc users list --autopaginate`.

--- a/resources/sdk/clisdkclient/templates/README.mustache
+++ b/resources/sdk/clisdkclient/templates/README.mustache
@@ -22,6 +22,8 @@ All access to Genesys Cloud is provided via OAuth client credentials.  Security 
 
 If you are using the CLI in a pipeline or don't wish to set up a config file, see [environment variables](#environment-variables) and [parameter overrides](#parameter-overrides).  
 
+The "environment" value can be provided as the API base path such as `mypurecloud.com` or AWS region.
+
 To setup and configure your gc CLI run `gc profiles new` command and answer the questions.  If everything works correctly you should have a file created in your home directory called .gc/config.toml.  If for some reason you have problems with the `gc profiles new` command, you can manually create the config file by following the steps below.
 
 -  Create .gc directory in your home directory
@@ -46,10 +48,12 @@ client_secret="OAUTH CLIENT SECRET"
 The following environment variables can be used as overrides or alternatives to their corresponding config file values
 
 ```
-GC_ENVIRONMENT
-GC_CLIENT_ID
-GC_CLIENT_SECRET
+GENESYSCLOUD_REGION
+GENESYSCLOUD_OAUTHCLIENT_ID
+GENESYSCLOUD_OAUTHCLIENT_SECRET
 ```
+
+`GENESYSCLOUD_REGION` can refer to the API base path or AWS region
 
 ## Parameter overrides
 

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -149,7 +149,7 @@ func Authorize(c config.Configuration) (models.OAuthTokenData, error) {
 	}
 
 	oAuthTokenData := &models.OAuthTokenData{}
-	if c.OAuthTokenData() != "" {
+	if !config.OverridesApplied() && c.OAuthTokenData() != "" {
 		err := json.Unmarshal([]byte(c.OAuthTokenData()), oAuthTokenData)
 		if err != nil {
 			return models.OAuthTokenData{}, err
@@ -232,9 +232,11 @@ func authorize(c config.Configuration) (models.OAuthTokenData, error) {
 		OAuthTokenExpiry: oAuthTokenExpiry.Format(time.RFC3339),
 	}
 
-	err = UpdateOAuthToken(c, oAuthTokenResponse)
-	if err != nil {
-		return *oAuthTokenResponse, err
+	if !config.OverridesApplied() {
+		err = UpdateOAuthToken(c, oAuthTokenResponse)
+		if err != nil {
+			return *oAuthTokenResponse, err
+		}
 	}
 
 	return *oAuthTokenResponse, nil

--- a/resources/sdk/clisdkclient/templates/root.mustache
+++ b/resources/sdk/clisdkclient/templates/root.mustache
@@ -61,7 +61,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&profileName, "profile", "p", "DEFAULT", "Name of the profile to use for configuring the cli")
 	rootCmd.PersistentFlags().BoolP("indicateprogress", "i", false, "Trace progress indicators to stderr")
 
-	rootCmd.PersistentFlags().StringVar(&config.Environment, "environment", "", "environment override. E.g. mypurecloud.com.au")
+	rootCmd.PersistentFlags().StringVar(&config.Environment, "environment", "", "environment override. E.g. mypurecloud.com.au or ap-southeast-2")
 	rootCmd.PersistentFlags().StringVar(&config.ClientId, "clientid", "", "clientId override")
 	rootCmd.PersistentFlags().StringVar(&config.ClientSecret, "clientsecret", "", "clientSecret override")
 

--- a/resources/sdk/clisdkclient/templates/root.mustache
+++ b/resources/sdk/clisdkclient/templates/root.mustache
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -59,6 +60,10 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&profileName, "profile", "p", "DEFAULT", "Name of the profile to use for configuring the cli")
 	rootCmd.PersistentFlags().BoolP("indicateprogress", "i", false, "Trace progress indicators to stderr")
+
+	rootCmd.PersistentFlags().StringVar(&config.Environment, "environment", "", "environment override. E.g. mypurecloud.com.au")
+	rootCmd.PersistentFlags().StringVar(&config.ClientId, "clientid", "", "clientId override")
+	rootCmd.PersistentFlags().StringVar(&config.ClientSecret, "clientsecret", "", "clientSecret override")
 
 	rootCmd.AddCommand(versionCmd)
 	{{addCommands}}


### PR DESCRIPTION
The following flags have been added:
--environment
--clientid
--clientsecret

The following env vars are now supported:
GENESYSCLOUD_OAUTHCLIENT_ID
GENESYSCLOUD_OAUTHCLIENT_SECRET
GENESYSCLOUD_REGION


I chose not to use `viper.BindEnv` for the environment variables because that would mean if any environment variables were set and the config was updated due to the user changing the log file path etc then the value of that variable would be written to the config file.
I didn't bind the flags to the config for the same reason.

