### PR TITLE
Using tripe curly braces to unescape HTML in dotnet API documentation code block

### DIFF
--- a/resources/sdk/pureclouddotnet/templates/api_doc.mustache
+++ b/resources/sdk/pureclouddotnet/templates/api_doc.mustache
@@ -64,7 +64,7 @@ namespace Example
             try
             { {{#summary}}
                 // {{{.}}}{{/summary}}
-                {{#returnType}}{{returnType}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
+                {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
                 Debug.WriteLine(result);{{/returnType}}
             }
             catch (Exception e)


### PR DESCRIPTION
The new developer centre isn't able to handle escaped HTML in code blocks.
Example: https://developer.genesys.cloud/api/rest/client-libraries/dotnet/ConversationsApi#getconversationparticipantwrapupcodes

I haven't seen any other issues in the SDK documentation.