### PR TITLE
.NET SDK: Allowing additional parameters in JSON reference objects

### DIFF
--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -25,7 +25,8 @@ namespace {{packageName}}.Client
     {
         private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
-            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore
         };
 
         /// <summary>

--- a/resources/sdk/pureclouddotnet/templates/modelGeneric.mustache
+++ b/resources/sdk/pureclouddotnet/templates/modelGeneric.mustache
@@ -79,7 +79,11 @@
         /// <returns>JSON string presentation of the object</returns>
         public {{#parent}} new {{/parent}}string ToJson()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonConvert.SerializeObject(this, new JsonSerializerSettings
+            {
+                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+                Formatting = Formatting.Indented
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Intended to fix SERVOPS-21590