### PR TITLE
Added a clause to prevent error being thrown when no config file exists.

### DIFF
--- a/resources/sdk/clisdkclient/extensions/config/config.go
+++ b/resources/sdk/clisdkclient/extensions/config/config.go
@@ -262,6 +262,10 @@ func updateConfig(c configuration, loggingEnabled *bool) error {
 		viper.Set(fmt.Sprintf("%s.logging_enabled", c.profileName), *loggingEnabled)
 	}
 
+	if viper.ConfigFileUsed() == "" {
+		return nil
+	}
+
 	return viper.WriteConfig()
 }
 


### PR DESCRIPTION
The error message that was thrown on `gc profiles new`:
```
Config File "config" Not Found in "[/$HOME/.gc /$HOME/path/to/platform-client-sdk-common]"
```

