### PR TITLE
allowing user to specify an access token during create profile, or as an environment variable or as a parameter override

### DIFF
--- a/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
@@ -74,7 +74,7 @@ func requestUserInput() config.Configuration {
 	}
 
 	fmt.Printf("Please provide either an Access Token, Client Credentials (Client ID and Client Secret) or both\n")
-	fmt.Printf("Note: If you provide an Access Token, this will be used over Client Credentials")
+	fmt.Printf("Note: If you provide an Access Token, this will be used over Client Credentials\n")
 	for {
 		fmt.Printf("Access Token: ")
 		fmt.Scanln(&accessToken)

--- a/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/profiles/createprofile.go
@@ -2,18 +2,19 @@ package profiles
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/logger"
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/mocks"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/restclient"
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
-	"strings"
+	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/restclient"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func constructConfig(profileName string, environment string, clientID string, clientSecret string) config.Configuration {
+func constructConfig(profileName string, environment string, clientID string, clientSecret string, accessToken string) config.Configuration {
 	c := &mocks.MockClientConfig{}
 
 	c.ProfileNameFunc = func() string {
@@ -44,6 +45,10 @@ func constructConfig(profileName string, environment string, clientID string, cl
 		return ""
 	}
 
+	c.AccessTokenFunc = func() string {
+		return accessToken
+	}
+
 	return c
 }
 
@@ -52,6 +57,7 @@ func requestUserInput() config.Configuration {
 	var environment string
 	var clientID string
 	var clientSecret string
+	var accessToken string
 
 	fmt.Print("Profile Name [DEFAULT]: ")
 	fmt.Scanln(&name)
@@ -67,23 +73,35 @@ func requestUserInput() config.Configuration {
 		environment = "mypurecloud.com"
 	}
 
-	for true {
+	fmt.Printf("Please provide either an Access Token, Client Credentials (Client ID and Client Secret) or both\n")
+	fmt.Printf("Note: If you provide an Access Token, this will be used over Client Credentials")
+	for {
+		fmt.Printf("Access Token: ")
+		fmt.Scanln(&accessToken)
 		fmt.Printf("Client ID: ")
 		fmt.Scanln(&clientID)
-		if len(strings.TrimSpace(clientID)) != 0 {
-			break
-		}
-	}
-
-	for true {
 		fmt.Printf("Client Secret: ")
 		fmt.Scanln(&clientSecret)
-		if len(strings.TrimSpace(clientSecret)) != 0 {
+		// users should only be allowed to continue if they provide an access token
+		if len(strings.TrimSpace(accessToken)) != 0 && len(strings.TrimSpace(clientID)) == 0 && len(strings.TrimSpace(clientSecret)) == 0 {
+			clientID = ""
+			clientSecret = ""
 			break
+			// or if they provide client credentials
+		} else if len(strings.TrimSpace(accessToken)) == 0 && len(strings.TrimSpace(clientID)) != 0 && len(strings.TrimSpace(clientSecret)) != 0 {
+			accessToken = ""
+			break
+			// or both
+		} else if len(strings.TrimSpace(accessToken)) != 0 && len(strings.TrimSpace(clientID)) != 0 && len(strings.TrimSpace(clientSecret)) != 0 {
+			break
+			// otherwise
+		} else {
+			fmt.Printf("Please provide either an Access Token, Client Credentials (Client ID and Client Secret) or both\n")
+			fmt.Printf("Note: If you provide an Access Token, this will be used over Client Credentials\n")
 		}
 	}
 
-	return constructConfig(name, environment, clientID, clientSecret)
+	return constructConfig(name, environment, clientID, clientSecret, accessToken)
 }
 
 func overrideConfig(name string) bool {
@@ -140,7 +158,7 @@ var createProfilesCmd = &cobra.Command{
 			logger.Fatal("Exiting profile creation process")
 		}
 
-		if validateCredentials(newConfig) == false {
+		if newConfig.AccessToken() == "" && validateCredentials(newConfig) == false {
 			logger.Fatal("The credentials provided are not valid.")
 		}
 

--- a/resources/sdk/clisdkclient/extensions/config/config.go
+++ b/resources/sdk/clisdkclient/extensions/config/config.go
@@ -139,7 +139,7 @@ func applyEnvironmentVariableOverrides() {
 	if clientSecret != "" && ClientSecret == "" {
 		ClientSecret = clientSecret
 	}
-	accessToken := os.Getenv("GENESYS_CLOUD_ACCESS_TOKEN")
+	accessToken := os.Getenv("GENESYSCLOUD_ACCESS_TOKEN")
 	if accessToken != "" && AccessToken == "" {
 		AccessToken = accessToken
 	}
@@ -283,7 +283,7 @@ func GetExperimentalFeature(profileName string, featureName string) bool {
 
 func OverridesApplied() bool {
 	return ClientId != "" || ClientSecret != "" || Environment != "" || AccessToken != "" ||
-		os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != "" || os.Getenv("GENESYS_CLOUD_ACCESS_TOKEN") != ""
+		os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != "" || os.Getenv("GENESYSCLOUD_ACCESS_TOKEN") != ""
 }
 
 func updateConfig(c configuration, loggingEnabled *bool) error {

--- a/resources/sdk/clisdkclient/extensions/config/config.go
+++ b/resources/sdk/clisdkclient/extensions/config/config.go
@@ -17,6 +17,7 @@ type Configuration interface {
 	ClientID() string
 	ClientSecret() string
 	OAuthTokenData() string
+	AccessToken() string
 	LogFilePath() string
 	LoggingEnabled() bool
 	fmt.Stringer
@@ -28,6 +29,7 @@ type configuration struct {
 	clientID       string
 	clientSecret   string
 	oAuthTokenData string
+	accessToken    string
 	logFilePath    string
 	loggingEnabled bool
 }
@@ -36,6 +38,7 @@ var (
 	Environment    string
 	ClientId       string
 	ClientSecret   string
+	AccessToken    string
 	regionMappings = map[string]string{
 		"us-east-1":      "mypurecloud.com",
 		"eu-west-1":      "mypurecloud.ie",
@@ -72,6 +75,14 @@ func (c *configuration) ClientSecret() string {
 	}
 
 	return viper.GetString(fmt.Sprintf("%s.client_secret", c.profileName))
+}
+
+func (c *configuration) AccessToken() string {
+	if AccessToken != "" {
+		return AccessToken
+	}
+
+	return viper.GetString(fmt.Sprintf("%s.access_token", c.profileName))
 }
 
 //OAuthTokenData is the raw OAuth token data returned from the login API call combined with the access token expiry timestamp
@@ -112,7 +123,7 @@ func (c *configuration) LoggingEnabled() bool {
 }
 
 func (c *configuration) String() string {
-	return fmt.Sprintf(`{"profileName": "%s", "environment": "%s", "logFilePath": "%s", "loggingEnabled": "%v", "clientName": "%s", "clientSecret": "%s"}`, c.ProfileName(), c.Environment(), c.LogFilePath(), c.LoggingEnabled(), c.ClientID(), c.ClientSecret())
+	return fmt.Sprintf(`{"profileName": "%s", "environment": "%s", "logFilePath": "%s", "loggingEnabled": "%v", "clientName": "%s", "clientSecret": "%s", "accessToken": "%s"}`, c.ProfileName(), c.Environment(), c.LogFilePath(), c.LoggingEnabled(), c.ClientID(), c.ClientSecret(), c.AccessToken())
 }
 
 func applyEnvironmentVariableOverrides() {
@@ -128,6 +139,10 @@ func applyEnvironmentVariableOverrides() {
 	if clientSecret != "" && ClientSecret == "" {
 		ClientSecret = clientSecret
 	}
+	accessToken := os.Getenv("GENESYS_CLOUD_ACCESS_TOKEN")
+	if accessToken != "" && AccessToken == "" {
+		AccessToken = accessToken
+	}
 }
 
 //GetConfig retrieves the config for the current profile
@@ -141,6 +156,7 @@ func GetConfig(profileName string) (Configuration, error) {
 					profileName:  profileName,
 					clientID:     ClientId,
 					clientSecret: ClientSecret,
+					accessToken:  AccessToken,
 					environment:  Environment,
 				}, nil
 			}
@@ -163,6 +179,7 @@ func GetConfig(profileName string) (Configuration, error) {
 		clientSecret:   viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
 		environment:    viper.GetString(fmt.Sprintf("%s.environment", profileName)),
 		oAuthTokenData: viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
+		accessToken:    viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
 		logFilePath:    viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
 		loggingEnabled: viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
 	}, nil
@@ -192,6 +209,7 @@ func ListConfigs() ([]configuration, error) {
 			clientSecret:   viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
 			environment:    viper.GetString(fmt.Sprintf("%s.environment", profileName)),
 			oAuthTokenData: viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
+			accessToken:    viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
 			logFilePath:    viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
 			loggingEnabled: viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
 		})
@@ -264,8 +282,8 @@ func GetExperimentalFeature(profileName string, featureName string) bool {
 }
 
 func OverridesApplied() bool {
-	return ClientId != "" || ClientSecret != "" || Environment != "" ||
-		os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != ""
+	return ClientId != "" || ClientSecret != "" || Environment != "" || AccessToken != "" ||
+		os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != "" || os.Getenv("GENESYS_CLOUD_ACCESS_TOKEN") != ""
 }
 
 func updateConfig(c configuration, loggingEnabled *bool) error {
@@ -280,6 +298,9 @@ func updateConfig(c configuration, loggingEnabled *bool) error {
 	}
 	if c.oAuthTokenData != "" {
 		viper.Set(fmt.Sprintf("%s.oauth_token_data", c.profileName), c.oAuthTokenData)
+	}
+	if c.accessToken != "" {
+		viper.Set(fmt.Sprintf("%s.access_token", c.profileName), c.accessToken)
 	}
 	if c.logFilePath != "" {
 		viper.Set(fmt.Sprintf("%s.log_file_path", c.profileName), c.logFilePath)
@@ -299,6 +320,7 @@ func writeConfig(c Configuration, data *models.OAuthTokenData, logFilePath strin
 	viper.Set(fmt.Sprintf("%s.client_credentials", c.ProfileName()), c.ClientID())
 	viper.Set(fmt.Sprintf("%s.client_secret", c.ProfileName()), c.ClientSecret())
 	viper.Set(fmt.Sprintf("%s.environment", c.ProfileName()), c.Environment())
+	viper.Set(fmt.Sprintf("%s.access_token", c.ProfileName()), c.AccessToken())
 	if data != nil {
 		viper.Set(fmt.Sprintf("%s.oauth_token_data", c.ProfileName()), data.String())
 	}

--- a/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
+++ b/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"fmt"
+
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
 	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
 )
@@ -12,6 +13,7 @@ type MockClientConfig struct {
 	ClientIDFunc       func() string
 	ClientSecretFunc   func() string
 	OAuthTokenDataFunc func() string
+	AccessTokenFunc    func() string
 	LogFilePathFunc    func() string
 	LoggingEnabledFunc func() bool
 }
@@ -38,6 +40,10 @@ func (m *MockClientConfig) OAuthTokenData() string {
 	return m.OAuthTokenDataFunc()
 }
 
+func (m *MockClientConfig) AccessToken() string {
+	return m.AccessTokenFunc()
+}
+
 func (m *MockClientConfig) LogFilePath() string {
 	return m.LogFilePathFunc()
 }
@@ -47,7 +53,7 @@ func (m *MockClientConfig) LoggingEnabled() bool {
 }
 
 func (m *MockClientConfig) String() string {
-	return fmt.Sprintf("\n-------------\nProfile Name: %s\nEnvironment: %s\nLogging Enabled: %v\nLog File Path: %s\nClient ID: %s\nClient Secret: %s\n--------------\n", m.ProfileName(), m.Environment(), m.LoggingEnabled(), m.LogFilePath(), m.ClientID(), m.ClientSecret())
+	return fmt.Sprintf("\n-------------\nProfile Name: %s\nEnvironment: %s\nLogging Enabled: %v\nLog File Path: %s\nClient ID: %s\nClient Secret: %s\nAccess Token: %s\n--------------\n", m.ProfileName(), m.Environment(), m.LoggingEnabled(), m.LogFilePath(), m.ClientID(), m.ClientSecret(), c.AccessToken())
 }
 
 func UpdateOAuthToken(_ config.Configuration, oauthTokenData *models.OAuthTokenData) error {

--- a/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
+++ b/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
@@ -53,7 +53,7 @@ func (m *MockClientConfig) LoggingEnabled() bool {
 }
 
 func (m *MockClientConfig) String() string {
-	return fmt.Sprintf("\n-------------\nProfile Name: %s\nEnvironment: %s\nLogging Enabled: %v\nLog File Path: %s\nClient ID: %s\nClient Secret: %s\nAccess Token: %s\n--------------\n", m.ProfileName(), m.Environment(), m.LoggingEnabled(), m.LogFilePath(), m.ClientID(), m.ClientSecret(), c.AccessToken())
+	return fmt.Sprintf("\n-------------\nProfile Name: %s\nEnvironment: %s\nLogging Enabled: %v\nLog File Path: %s\nClient ID: %s\nClient Secret: %s\nAccess Token: %s\n--------------\n", m.ProfileName(), m.Environment(), m.LoggingEnabled(), m.LogFilePath(), m.ClientID(), m.ClientSecret(), m.AccessToken())
 }
 
 func UpdateOAuthToken(_ config.Configuration, oauthTokenData *models.OAuthTokenData) error {

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -447,9 +447,9 @@ func (c *commandService) upsert(method string, uri string, payload string) (stri
 }
 
 func reAuthenticateIfNecessary(config config.Configuration, err error) error {
-	// do not re-authenticate if we have an access_token as we want to use the access token over client credentials
+	// do not re-authenticate with client credentials if we have an access_token as we want to use the access token over client credentials
 	if config.AccessToken() != "" {
-		return err
+		logger.Fatal("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.\n")
 	}
 
 	if hasReAuthenticated {

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -455,7 +455,8 @@ func reAuthenticateIfNecessary(config config.Configuration, err error) error {
 	if e, ok := err.(models.HttpStatusError); ok && e.StatusCode == http.StatusUnauthorized {
 		// do not re-authenticate with client credentials if we have an access_token
 		if config.AccessToken() != "" {
-			logger.Warn("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.")
+			logger.Warn("unauthorized. your access_token has either expired or is not valid. please authenticate")
+			err := fmt.Errorf("unauthorized. your access_token has either expired or is not valid. please authenticate")
 			return err
 		}
 		logger.Info("Received HTTP 401 error, re-authenticating")

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -447,18 +447,17 @@ func (c *commandService) upsert(method string, uri string, payload string) (stri
 }
 
 func reAuthenticateIfNecessary(config config.Configuration, err error) error {
-	// do not re-authenticate with client credentials if we have an access_token as we want to use the access token over client credentials
-	if config.AccessToken() != "" {
-		//logger.Fatal("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.\n")
-		return err
-	}
-
 	if hasReAuthenticated {
 		logger.Warn("Have already re-authenticated. Will not authenticate again")
 		return err
 	}
 
 	if e, ok := err.(models.HttpStatusError); ok && e.StatusCode == http.StatusUnauthorized {
+		// do not re-authenticate with client credentials if we have an access_token
+		if config.AccessToken() != "" {
+			logger.Warn("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.")
+			return err
+		}
 		logger.Info("Received HTTP 401 error, re-authenticating")
 		_, err = restclient.ReAuthenticate(config)
 		if err != nil {

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -449,7 +449,7 @@ func (c *commandService) upsert(method string, uri string, payload string) (stri
 func reAuthenticateIfNecessary(config config.Configuration, err error) error {
 	// do not re-authenticate with client credentials if we have an access_token as we want to use the access token over client credentials
 	if config.AccessToken() != "" {
-		logger.Fatal("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.\n")
+		//logger.Fatal("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.\n")
 		return err
 	}
 

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -450,6 +450,7 @@ func reAuthenticateIfNecessary(config config.Configuration, err error) error {
 	// do not re-authenticate with client credentials if we have an access_token as we want to use the access token over client credentials
 	if config.AccessToken() != "" {
 		logger.Fatal("Unauthorized. Your Access Token has either expired or is not valid. Please authenticate.\n")
+		return err
 	}
 
 	if hasReAuthenticated {

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -447,6 +447,11 @@ func (c *commandService) upsert(method string, uri string, payload string) (stri
 }
 
 func reAuthenticateIfNecessary(config config.Configuration, err error) error {
+	// do not re-authenticate if we have an access_token as we want to use the access token over client credentials
+	if config.AccessToken() != "" {
+		return err
+	}
+
 	if hasReAuthenticated {
 		logger.Warn("Have already re-authenticated. Will not authenticate again")
 		return err

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -147,20 +147,17 @@ func TestReAuthenticationWithAccessToken(t *testing.T) {
 		cmd: &cobra.Command{},
 	}
 
-	tc := apiClientTest{
-		targetStatusCode:   http.StatusUnauthorized,
-		expectedStatusCode: http.StatusUnauthorized,
-		// expectedResponse is an empty string because when making a reuest, if there is an err returned from commandservice.reauthenticateIfNecessary(),
-		// (which in our case there will be, because we do not want to re-authenticate if we have an access token)
-		// the empty string and error are returned from the caller (commandservice.upsert())
-		expectedResponse: ``,
-	}
+	// expectedResponse is the empty string because when making a reuest with a "bad" access token, a 401 error is returned and commandservice.reauthenticateIfNecessary() is called
+	// and if there is an err returned from commandservice.reauthenticateIfNecessary(),
+	// (which in our case there will be, because we do not want to re-authenticate if we have an access token, we just want to return an error)
+	// the empty string and error are returned from the caller (e.g commandservice.upsert() or commandservice.Get())
+	expectedResponse := ""
 
 	// so the expected value from this GET request is the empty string and we do not care about the error returned
 	value, _ := c.Get("")
 
-	if value != tc.expectedResponse {
-		t.Errorf("Did not get the right value, got: %s, want: %s.", value, tc.expectedResponse)
+	if value != expectedResponse {
+		t.Errorf("Did not get the right value, got: %s, want: %s.", value, expectedResponse)
 	}
 }
 

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -269,5 +269,9 @@ func mockGetConfig(profileName string) (config.Configuration, error) {
 		return ""
 	}
 
+	mockConfig.AccessTokenFunc = func() string {
+		return ""
+	}
+
 	return mockConfig, nil
 }

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -118,21 +118,20 @@ func TestReAuthenticationWithAccessToken(t *testing.T) {
 		cmd: &cobra.Command{},
 	}
 
-	// expectedResponse is the empty string because when making a reuest with a "bad" access token (e.g in commandservice.Get()), a 401 error is returned and commandservice.reauthenticateIfNecessary() is called,
-	// when we have an access token in config we will return an error from commandservice.reauthenticateIfNecessary() and not continue to reauthenticate,
-	// when an error is returned from commandservice.reauthenticateIfNecessary(), the empty string and error are returned from the caller (e.g commandservice.upsert() or commandservice.Get())
 	tc := apiClientTest{
 		targetStatusCode:   http.StatusUnauthorized,
 		expectedStatusCode: http.StatusUnauthorized,
-		expectedResponse:   ``,
+		expectedResponse:   "",
 	}
 	setRestClientDoMockForReAuthenticate(tc)
 
-	// so the expected value from this GET request, when we have an access token in config, is the empty string and we do not care about the error returned
-	value, _ := c.Get("")
+	// the expected err from this GET request, when we have an access token in config, is the error msg below, and we do not care about the empty string returned
+	_, err := c.Get("")
 
-	if value != tc.expectedResponse {
-		t.Errorf("Did not get the right value, got: %s, want: %s.", value, tc.expectedResponse)
+	expectedErr := "unauthorized. your access_token has either expired or is not valid. please authenticate"
+
+	if err.Error() != expectedErr {
+		t.Errorf("Did not get the right value, got: %s, want: %s.", err.Error(), expectedErr)
 	}
 }
 

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -43,7 +43,6 @@ client_secret="OAUTH CLIENT SECRET"
 [test_pro_2]
 environment="mypurecloud.com"
 access_token="OAUTH ACCESS TOKEN"
-
 ```
 
 **Note:** You can setup up multiple profiles.  The default profile is what will be used by the CLI by default.  You can use a different profile by passing in a `-p=profile_name` flag on the CLI.

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -35,10 +35,15 @@ environment="mypurecloud.com"
 client_credentials="OAUTH CLIENT CREDENTIAL GRANT"
 client_secret="OAUTH CLIENT SECRET"
 
-[test]
+[test_pro_1]
 environment="mypurecloud.com"
 client_credentials="OAUTH CLIENT CREDENTIAL GRANT"
 client_secret="OAUTH CLIENT SECRET"
+
+[test_pro_2]
+environment="mypurecloud.com"
+access_token="OAUTH ACCESS TOKEN"
+
 ```
 
 **Note:** You can setup up multiple profiles.  The default profile is what will be used by the CLI by default.  You can use a different profile by passing in a `-p=profile_name` flag on the CLI.
@@ -51,6 +56,7 @@ The following environment variables can be used as overrides or alternatives to 
 GENESYSCLOUD_REGION
 GENESYSCLOUD_OAUTHCLIENT_ID
 GENESYSCLOUD_OAUTHCLIENT_SECRET
+GENESYSCLOUD_ACCESS_TOKEN
 ```
 
 `GENESYSCLOUD_REGION` can refer to the API base path or AWS region
@@ -63,6 +69,7 @@ The following flags can be used as overrides or alternatives to their correspond
 --environment
 --clientid
 --clientsecret
+--accesstoken
 ```
 
 # Using the CLI

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -245,15 +245,17 @@ func authorize(c config.Configuration) (models.OAuthTokenData, error) {
 
 //NewRESTClient is a constructor function to build an APIClient
 func NewRESTClient(config config.Configuration) *RESTClient {
-	if RestClient == nil {
+	if RestClient == nil && config.AccessToken() == "" {
 		oAuthToken, err := Authorize(config)
 		if err != nil {
 			logger.Fatal(err)
 		}
 
 		RestClient = &RESTClient{environment: config.Environment(), token: oAuthToken.AccessToken}
+		return RestClient
 	}
 
+	RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken()}
 	return RestClient
 }
 

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -255,7 +255,12 @@ func NewRESTClient(config config.Configuration) *RESTClient {
 		return RestClient
 	}
 
-	RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken()}
+	if RestClient == nil && config.AccessToken() != "" {
+		fmt.Println("not in authorize block we have an access token")
+		RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken()}
+
+	}
+
 	return RestClient
 }
 

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -256,9 +256,7 @@ func NewRESTClient(config config.Configuration) *RESTClient {
 	}
 
 	if RestClient == nil && config.AccessToken() != "" {
-		fmt.Println("not in authorize block we have an access token")
 		RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken()}
-
 	}
 
 	return RestClient

--- a/resources/sdk/clisdkclient/templates/root.mustache
+++ b/resources/sdk/clisdkclient/templates/root.mustache
@@ -140,6 +140,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&config.Environment, "environment", "", "environment override. E.g. mypurecloud.com.au or ap-southeast-2")
 	rootCmd.PersistentFlags().StringVar(&config.ClientId, "clientid", "", "clientId override")
 	rootCmd.PersistentFlags().StringVar(&config.ClientSecret, "clientsecret", "", "clientSecret override")
+	rootCmd.PersistentFlags().StringVar(&config.AccessToken, "accesstoken", "", "accessToken override")
 
 	if config.GetExperimentalFeature(getProfileName(os.Args), models.AlternativeFormats.String()) {
 		rootCmd.PersistentFlags().StringVar(&data_format.InputFormat, "inputformat", "", "Data input format. Supported formats: YAML, JSON")


### PR DESCRIPTION
1. Create profile flow updated to allow for either an access token, client credentials or both during create profile. If a user provides an access token, this will be used over client credentials.
2.  An environment variable GENESYS_CLOUD_ACCESS_TOKEN can also be used to set the token. This will take priority over an access token in config.
3. A parameter override --accesstoken can also be used to set the token. This will take priority over a token set as an environment variable or a token in config.