### PR TITLE
Slurping in multiple files from a directory for "bulk" creating or updating data.

### DIFF
--- a/resources/sdk/clisdkclient/extensions/retry/retry.go
+++ b/resources/sdk/clisdkclient/extensions/retry/retry.go
@@ -31,22 +31,34 @@ func RetryWithData(uri string, data []string, httpCall func(uri string, data str
 		}
 		retryConfiguration = retryConfig
 
+		// if there is only one item in the array (req body), then just return the response object
+		if len(data) == 1 {
+			res, err := httpCall(uri, data[0])
+			return res, err
+		}
+
+		// if there is more than one item in the array (req bodies), the response will be an array of response objects
 		var response string = "["
-		var er error
-		for i := 0; i < len(data); i++ {
-			res, err := httpCall(uri, data[i])
+		for i, reqBody := range data {
+			res, err := httpCall(uri, reqBody)
 			retryConfiguration = nil
 			if err != nil {
-				er = err
-			}
-			if i == len(data)-1 {
-				response += res + "]"
+				if i == len(data)-1 {
+					response += err.Error() + "]"
+				} else {
+					response += err.Error() + ","
+				}
 			} else {
-				response += res + ",\n"
+				if i == len(data)-1 {
+					response += res + "]"
+				} else {
+					response += res + ","
+				}
 			}
 		}
 
-		return response, er
+		// returning response and nil error as the error objects will be concatenated onto the response (if there are any)
+		return response, nil
 	}
 }
 

--- a/resources/sdk/clisdkclient/extensions/retry/retry.go
+++ b/resources/sdk/clisdkclient/extensions/retry/retry.go
@@ -20,7 +20,7 @@ func GetRetryConfiguration() *RetryConfiguration {
 
 type RequestLogHook func(*http.Request, int)
 
-func RetryWithData(uri string, data string, httpCall func(uri string, data string) (string, error)) func(retryConfig *RetryConfiguration) (string, error) {
+func RetryWithData(uri string, data []string, httpCall func(uri string, data string) (string, error)) func(retryConfig *RetryConfiguration) (string, error) {
 	return func(retryConfig *RetryConfiguration) (string, error) {
 		if retryConfig == nil {
 			retryConfig = &RetryConfiguration{
@@ -31,10 +31,22 @@ func RetryWithData(uri string, data string, httpCall func(uri string, data strin
 		}
 		retryConfiguration = retryConfig
 
-		response, err := httpCall(uri, data)
-		retryConfiguration = nil
+		var response string = "["
+		var er error
+		for i := 0; i < len(data); i++ {
+			res, err := httpCall(uri, data[i])
+			retryConfiguration = nil
+			if err != nil {
+				er = err
+			}
+			if i == len(data)-1 {
+				response += res + "]"
+			} else {
+				response += res + ",\n"
+			}
+		}
 
-		return response, err
+		return response, er
 	}
 }
 

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -492,18 +492,21 @@ func (c *commandService) DetermineAction(httpMethod string, uri string, flags *p
 		}
 		return retry.Retry(uri, c.List)
 	case http.MethodPatch:
-		if flags.Lookup("file") == nil {
-			return retry.RetryWithData(uri, "", c.Patch)
+		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
+			someArr := []string{}
+			return retry.RetryWithData(uri, someArr, c.Patch)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Patch)
 	case http.MethodPost:
-		if flags.Lookup("file") == nil {
-			return retry.RetryWithData(uri, "", c.Post)
+		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
+			someArr := []string{}
+			return retry.RetryWithData(uri, someArr, c.Post)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Post)
 	case http.MethodPut:
-		if flags.Lookup("file") == nil {
-			return retry.RetryWithData(uri, "", c.Put)
+		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
+			someArr := []string{}
+			return retry.RetryWithData(uri, someArr, c.Put)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Put)
 	case http.MethodDelete:

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -493,17 +493,17 @@ func (c *commandService) DetermineAction(httpMethod string, uri string, flags *p
 		return retry.Retry(uri, c.List)
 	case http.MethodPatch:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			return retry.RetryWithData(uri, []string{}, c.Patch)
+			return retry.RetryWithData(uri, []string{""}, c.Patch)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Patch)
 	case http.MethodPost:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			return retry.RetryWithData(uri, []string{}, c.Post)
+			return retry.RetryWithData(uri, []string{""}, c.Post)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Post)
 	case http.MethodPut:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			return retry.RetryWithData(uri, []string{}, c.Put)
+			return retry.RetryWithData(uri, []string{""}, c.Put)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Put)
 	case http.MethodDelete:

--- a/resources/sdk/clisdkclient/extensions/services/commandservice.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice.go
@@ -493,20 +493,17 @@ func (c *commandService) DetermineAction(httpMethod string, uri string, flags *p
 		return retry.Retry(uri, c.List)
 	case http.MethodPatch:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			someArr := []string{}
-			return retry.RetryWithData(uri, someArr, c.Patch)
+			return retry.RetryWithData(uri, []string{}, c.Patch)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Patch)
 	case http.MethodPost:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			someArr := []string{}
-			return retry.RetryWithData(uri, someArr, c.Post)
+			return retry.RetryWithData(uri, []string{}, c.Post)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Post)
 	case http.MethodPut:
 		if flags.Lookup("file") == nil || flags.Lookup("directory") == nil {
-			someArr := []string{}
-			return retry.RetryWithData(uri, someArr, c.Put)
+			return retry.RetryWithData(uri, []string{}, c.Put)
 		}
 		return retry.RetryWithData(uri, utils.ResolveInputData(c.cmd), c.Put)
 	case http.MethodDelete:

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -49,7 +49,7 @@ func TestRetryWithData(t *testing.T) {
 		expectedStatusCode: http.StatusTooManyRequests}
 	setRestClientDoMockForRetry(tc, 10)
 
-	retryFunc := retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
+	retryFunc := retry.RetryWithData(tc.targetPath, []string{""}, c.Patch)
 	retryConfig := &retry.RetryConfiguration{
 		RetryWaitMax: 100 * time.Second,
 		RetryMax:     maxRetriesBeforeQuitting,
@@ -75,7 +75,7 @@ func TestRetryWithData(t *testing.T) {
 	tc.expectedResponse = fmt.Sprintf(`{"numRetries":"%v"}`, expectedNumCalls)
 	setRestClientDoMockForRetry(tc, 10)
 
-	retryFunc = retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
+	retryFunc = retry.RetryWithData(tc.targetPath, []string{""}, c.Patch)
 	retryConfig.RetryWaitMax = maxRetryTimeSec
 	_, err = retryFunc(retryConfig)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestRetryWithData(t *testing.T) {
 	tc.expectedResponse = fmt.Sprintf(`{"numRetries":"%v"}`, expectedNumCalls)
 	setRestClientDoMockForRetry(tc, 3)
 
-	retryFunc = retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
+	retryFunc = retry.RetryWithData(tc.targetPath, []string{""}, c.Patch)
 	retryConfig.RetryMax = maxRetriesBeforeQuitting
 	results, err := retryFunc(retryConfig)
 	if err != nil {

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -49,7 +49,7 @@ func TestRetryWithData(t *testing.T) {
 		expectedStatusCode: http.StatusTooManyRequests}
 	setRestClientDoMockForRetry(tc, 10)
 
-	retryFunc := retry.RetryWithData(tc.targetPath, "", c.Patch)
+	retryFunc := retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
 	retryConfig := &retry.RetryConfiguration{
 		RetryWaitMax: 100 * time.Second,
 		RetryMax:     maxRetriesBeforeQuitting,
@@ -75,7 +75,7 @@ func TestRetryWithData(t *testing.T) {
 	tc.expectedResponse = fmt.Sprintf(`{"numRetries":"%v"}`, expectedNumCalls)
 	setRestClientDoMockForRetry(tc, 10)
 
-	retryFunc = retry.RetryWithData(tc.targetPath, "", c.Patch)
+	retryFunc = retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
 	retryConfig.RetryWaitMax = maxRetryTimeSec
 	_, err = retryFunc(retryConfig)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestRetryWithData(t *testing.T) {
 	tc.expectedResponse = fmt.Sprintf(`{"numRetries":"%v"}`, expectedNumCalls)
 	setRestClientDoMockForRetry(tc, 3)
 
-	retryFunc = retry.RetryWithData(tc.targetPath, "", c.Patch)
+	retryFunc = retry.RetryWithData(tc.targetPath, []string{}, c.Patch)
 	retryConfig.RetryMax = maxRetriesBeforeQuitting
 	results, err := retryFunc(retryConfig)
 	if err != nil {

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -281,10 +281,13 @@ func ConvertFile(fileName string) string {
 func readDirectory(dirName string) []string {
 	files, err := ioutil.ReadDir(dirName)
 	if err != nil {
-		logger.Fatal(fmt.Sprintf("Unable to open directory %s.", dirName), err)
+		logger.Fatal(fmt.Sprintf("Error reading %s: ", dirName), err)
+	}
+	if len(files) == 0 {
+		logger.Fatal(fmt.Sprintf("Error reading %s: no files in directory\n", dirName))
 	}
 
-	data := []string{}
+	var data []string
 
 	for _, file := range files {
 		fileName := dirName + file.Name()

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -65,7 +65,7 @@ func AddFileFlagIfUpsert(flags *pflag.FlagSet, method string, jsonSchema string)
 	case http.MethodPut:
 		flags.StringP("file", "f", "", "File name containing the JSON body")
 		flags.BoolP("printrequestbody", "b", false, "Print the request body format of the API.")
-		flags.StringP("directory", "d", "", "Directory path containing JSON files")
+		flags.StringP("directory", "d", "", "Directory path with files containing request bodies")
 	}
 }
 

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -277,20 +277,28 @@ func ConvertFile(fileName string) string {
 	return convertToJSON(string(fileContent))
 }
 
-func readDirectory(dirName string) []string {
+func readDirectory(dirName string) string {
 	files, err := ioutil.ReadDir(dirName)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Fatal(fmt.Sprintf("Unable to open directory %s.", dirName), err)
 	}
 
-	arr := []string{}
+	jsonStr := "["
 
-	for _, file := range files {
-		fileName := "./gc/users-test-data/" + file.Name()
-		arr = append(arr, ConvertFile(fileName))
+	for i, file := range files {
+		strLen := len(dirName)
+		fileName := dirName + file.Name()
+		if dirName[strLen-1] != '/' {
+			fileName = dirName + "/" + file.Name()
+		}
+		if i == len(files)-1 {
+			jsonStr += ConvertFile(fileName) + "]"
+		} else {
+			jsonStr += ConvertFile(fileName) + ",\n"
+		}
 	}
 
-	return arr
+	return jsonStr
 }
 
 // ResolveInputData is used to determine where the Put, Patch and Delete Post data should be read from
@@ -301,8 +309,13 @@ func ResolveInputData(cmd *cobra.Command) string {
 	}
 	for _, command := range cmd.Commands() {
 		fileName, _ := command.Flags().GetString("file")
+		dirName, _ := command.Flags().GetString("directory")
 		if fileName != "" {
 			return ConvertFile(fileName)
+		}
+		if dirName != "" {
+			fmt.Println(readDirectory(dirName))
+			return readDirectory(dirName)
 		}
 	}
 

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -277,6 +277,22 @@ func ConvertFile(fileName string) string {
 	return convertToJSON(string(fileContent))
 }
 
+func readDirectory(dirName string) []string {
+	files, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	arr := []string{}
+
+	for _, file := range files {
+		fileName := "./gc/users-test-data/" + file.Name()
+		arr = append(arr, ConvertFile(fileName))
+	}
+
+	return arr
+}
+
 // ResolveInputData is used to determine where the Put, Patch and Delete Post data should be read from
 func ResolveInputData(cmd *cobra.Command) string {
 	fileName, _ := cmd.Flags().GetString("file")

--- a/resources/sdk/clisdkclient/extensions/utils/general.go
+++ b/resources/sdk/clisdkclient/extensions/utils/general.go
@@ -277,41 +277,37 @@ func ConvertFile(fileName string) string {
 	return convertToJSON(string(fileContent))
 }
 
-func readDirectory(dirName string) string {
+func readDirectory(dirName string) []string {
 	files, err := ioutil.ReadDir(dirName)
 	if err != nil {
 		logger.Fatal(fmt.Sprintf("Unable to open directory %s.", dirName), err)
 	}
 
-	jsonStr := "["
+	arr := []string{}
 
-	for i, file := range files {
+	for _, file := range files {
 		strLen := len(dirName)
 		fileName := dirName + file.Name()
 		if dirName[strLen-1] != '/' {
 			fileName = dirName + "/" + file.Name()
 		}
-		if i == len(files)-1 {
-			jsonStr += ConvertFile(fileName) + "]"
-		} else {
-			jsonStr += ConvertFile(fileName) + ",\n"
-		}
+		arr = append(arr, ConvertFile(fileName))
 	}
 
-	return jsonStr
+	return arr
 }
 
 // ResolveInputData is used to determine where the Put, Patch and Delete Post data should be read from
-func ResolveInputData(cmd *cobra.Command) string {
+func ResolveInputData(cmd *cobra.Command) []string {
 	fileName, _ := cmd.Flags().GetString("file")
 	if fileName != "" {
-		return ConvertFile(fileName)
+		//return ConvertFile(fileName)
 	}
 	for _, command := range cmd.Commands() {
 		fileName, _ := command.Flags().GetString("file")
 		dirName, _ := command.Flags().GetString("directory")
 		if fileName != "" {
-			return ConvertFile(fileName)
+			//return ConvertFile(fileName)
 		}
 		if dirName != "" {
 			fmt.Println(readDirectory(dirName))
@@ -319,7 +315,8 @@ func ResolveInputData(cmd *cobra.Command) string {
 		}
 	}
 
-	return ConvertStdInString()
+	//return ConvertStdInString()
+	return []string{}
 }
 
 func GenerateGuid() string {

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -420,6 +420,24 @@ To perform a delete:
 gc users delete [userId]
 ```
 
+To create or update multiple objects, you can pass a directory path to the `--directory` flag or to the `-d` short flag containing JSON files, where each file is a request body for either creating or updating data.
+
+For example, creating multiple user objects:
+
+`./users-directory`
+
+```
+user-1.json // each file is a request body for creating a user
+user-2.json
+user-3.json
+```
+
+To create multiple users, run the following command:
+
+```
+gc users create -d ./users-directory
+```
+
 # Additional Tools
 Since this is a CLI, the output from the tool can be passed to other command tools and scripts.  Two of the most common helpful tools are:
 


### PR DESCRIPTION
Allowing users to provide a directory path to the --directory flag or to the -d short flag containing request bodies to "bulk" create or update data. For example, bulk creating or updating user data. If there is one file in the directory, the response will be a single object (similar to how the --file flag would work when provided with a single file for making a request). If there is more than one file (request bodies) in the directory then the response will be and array of objects returned from each individual request. If there are errors with any of the requests, the error objects will be concatenated onto the response where the successful response object would have been otherwise.