### PR TITLE
NO-JIRA - Made a small change to how YAML data is printed.

### DIFF
--- a/resources/sdk/clisdkclient/extensions/utils/render.go
+++ b/resources/sdk/clisdkclient/extensions/utils/render.go
@@ -18,6 +18,7 @@ func Render(data string) {
 		if err != nil {
 			logger.Fatalf("Error converting JSON to YAML: %v\n", err)
 		}
+		fmt.Println("---")
 		fmt.Printf("%s", result)
 		return
 	}


### PR DESCRIPTION
I added `---` to the line preceding a YAML response object. I think this could be more convenient for when a user wants to process multiple YAML response bodies stored in the same file as they would be separated.