### PR TITLE
GO SDK: Setting formParams and headerParams if not empty instead of nil

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -110,7 +110,7 @@ func (c *APIClient) CallAPI(path string, method string,
 	}
 
 	// Set form data
-	if formParams != nil {
+	if len(formParams) > 0 {
 		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		request.SetBody(ioutil.NopCloser(strings.NewReader(formParams.Encode())))
 	}
@@ -123,7 +123,7 @@ func (c *APIClient) CallAPI(path string, method string,
 	}
 
 	// Set provided headers
-	if headerParams != nil {
+	if len(headerParams) > 0 {
 		for k, v := range headerParams {
 			request.Header.Set(k, v)
 		}


### PR DESCRIPTION
This is to avoid the 400 bad request issue when the SDK is used in terraform making requests against lower environments.
I'm yet to find out why it only happens in lower envs and within terraform.