### PR TITLE
Added check for '/' suffix in os.TempDir

### DIFF
--- a/resources/sdk/clisdkclient/extensions/restclient/tls/generate_cert.go
+++ b/resources/sdk/clisdkclient/extensions/restclient/tls/generate_cert.go
@@ -18,12 +18,13 @@ import (
 	"encoding/pem"
 	"math/big"
 	"os"
+	"strings"
 	"time"
 )
 
 const (
 	host     = "localhost"
-	validFor = 365*24*time.Hour
+	validFor = 365 * 24 * time.Hour
 	rsaBits  = 2048
 )
 
@@ -33,8 +34,20 @@ var (
 )
 
 func GenerateCerts() error {
-	var priv interface{}
-	var err error
+	var (
+		priv           interface{}
+		err            error
+		pathToCertFile string
+		pathToKeyFile  string
+		tmpDir         = os.TempDir()
+	)
+
+	if !strings.HasSuffix(tmpDir, "/") {
+		tmpDir += "/"
+	}
+
+	pathToCertFile = tmpDir + certFileName
+	pathToKeyFile = tmpDir + keyFileName
 
 	priv, err = rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
@@ -79,7 +92,7 @@ func GenerateCerts() error {
 	}
 
 	// Write cert.pem to temporary folder
-	certOut, err := os.Create(os.TempDir() + certFileName)
+	certOut, err := os.Create(pathToCertFile)
 	if err != nil {
 		return err
 	}
@@ -91,7 +104,7 @@ func GenerateCerts() error {
 	}
 
 	// Write key.pem to temporary folder
-	keyOut, err := os.OpenFile(os.TempDir() + keyFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(pathToKeyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/resources/sdk/clisdkclient/extensions/restclient/tls/generate_cert_test.go
+++ b/resources/sdk/clisdkclient/extensions/restclient/tls/generate_cert_test.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -9,23 +10,31 @@ func TestGenerateCerts(t *testing.T) {
 	keyFileName = "testkey.pem"
 	certFileName = "testcert.pem"
 
+	tmpDir := os.TempDir()
+	if !strings.HasSuffix(tmpDir, "/") {
+		tmpDir += "/"
+	}
+
+	pathToKeyFile := tmpDir + keyFileName
+	pathToCertFile := tmpDir + certFileName
+
 	err := GenerateCerts()
 	if err != nil {
 		t.Fatalf("err should be nil, got: %s", err)
 	}
 
 	// Check to see that key and cert were written to os.TempDir()
-	if _, err = os.Stat(os.TempDir() + keyFileName); os.IsNotExist(err) {
-		t.Fatalf("File %s should exist in %s but does not. Error: %s", keyFileName, os.TempDir(), err)
+	if _, err = os.Stat(pathToKeyFile); os.IsNotExist(err) {
+		t.Fatalf("File %s should exist in %s but does not. Error: %s", keyFileName, tmpDir, err)
 	}
-	if _, err = os.Stat(os.TempDir() + certFileName); os.IsNotExist(err) {
-		t.Fatalf("File %s should exist in %s but does not. Error: %s", certFileName, os.TempDir(), err)
+	if _, err = os.Stat(pathToCertFile); os.IsNotExist(err) {
+		t.Fatalf("File %s should exist in %s but does not. Error: %s", certFileName, tmpDir, err)
 	}
 
 	defer func() {
 		// Delete files from tmp folder
-		_ = os.Remove(os.TempDir() + keyFileName)
-		_ = os.Remove(os.TempDir() + certFileName)
+		_ = os.Remove(pathToKeyFile)
+		_ = os.Remove(pathToCertFile)
 
 		keyFileName = "key.pem"
 		certFileName = "cert.pem"


### PR DESCRIPTION
The error `restclient_test.go:101: err should be nil, got: open /tmpcert.pem: permission denied` in the jenkins build seems to have been caused by the value in `os.TempDir()` not including a / character at the end. This change should fix that 