### PR TITLE
rolling back jackson version for java sdk

### DIFF
--- a/resources/sdk/purecloudjava/templates/pom.xml
+++ b/resources/sdk/purecloudjava/templates/pom.xml
@@ -347,7 +347,7 @@
     <swagger-annotations-version>1.6.6</swagger-annotations-version>
     <slf4j-version>1.7.36</slf4j-version>
     <jersey-version>1.19.1</jersey-version>
-    <jackson-version>2.13.2.1</jackson-version>
+    <jackson-version>2.13.2</jackson-version>
     <jodatime-version>2.10.14</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <testng-version>7.5</testng-version>


### PR DESCRIPTION
jackson version 2.13.2.1 could not be found in maven central causing a build failure, so rolling back to version 2.13.2