### PR TITLE
fix dependabot ignore dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,29 +5,29 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "resources/sdk/purecloudjava/templates/" # Location of package manifests
+  - package-ecosystem: 'maven'
+    directory: 'resources/sdk/purecloudjava/templates/' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'daily'
     ignore:
-      - dependency-name: "testng*"
+      - dependency-name: 'org.testng:testng'
 
-  - package-ecosystem: "maven"
-    directory: "resources/sdk/purecloudjava-guest/templates/"
+  - package-ecosystem: 'maven'
+    directory: 'resources/sdk/purecloudjava-guest/templates/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
 
-  - package-ecosystem: "maven"
-    directory: "resources/sdk/webmessagingjava/templates/"
+  - package-ecosystem: 'maven'
+    directory: 'resources/sdk/webmessagingjava/templates/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
 
-  - package-ecosystem: "gomod"
-    directory: "resources/sdk/clisdkclient/extensions/"
+  - package-ecosystem: 'gomod'
+    directory: 'resources/sdk/clisdkclient/extensions/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
 
-  - package-ecosystem: "pip"
-    directory: "resources/sdk/purecloudpython/templates/"
+  - package-ecosystem: 'pip'
+    directory: 'resources/sdk/purecloudpython/templates/'
     schedule:
-      interval: "daily"
+      interval: 'daily'


### PR DESCRIPTION
according to [Specifying dependencies and versions to ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore:~:text=dependency%2Dname%20attribute%20is%3A%20groupId%3AartifactId%20(for%20example%3A%20org.kohsuke%3Agithub%2Dapi))