### PR TITLE
fixing dependabot ignore dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "testng*"
+      - dependency-name: "org.testng:testng"
 
   - package-ecosystem: "maven"
     directory: "resources/sdk/purecloudjava-guest/templates/"


### PR DESCRIPTION
according to [Specifying dependencies and versions to ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore:~:text=For%20Java%20dependencies%2C%20the%20format%20of%20the%20dependency%2Dname%20attribute%20is%3A%20groupId%3AartifactId%20(for%20example%3A%20org.kohsuke%3Agithub%2Dapi))