### PR TITLE
Devengage 1323 purecloudgo remove omitempty optional properties

### DIFF
--- a/resources/sdk/purecloudgo/extensions/platformclientv2_test.go
+++ b/resources/sdk/purecloudgo/extensions/platformclientv2_test.go
@@ -19,7 +19,6 @@ type testConfig struct {
 	usersAPI            *UsersApi
 	JourneyAPI          *JourneyApi
 	PatchSegment        Patchsegment
-	PatchConfiguration  PatchConfiguration
 	journeySegmentId    string
 	userID              string
 	userName            string

--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -17,8 +17,8 @@ import (
 
 // APIClient provides functions for making API requests
 type APIClient struct {
-	client             retryablehttp.Client
-	configuration      *Configuration
+	client        retryablehttp.Client
+	configuration *Configuration
 }
 
 // NewAPIClient creates a new API client
@@ -118,7 +118,6 @@ func (c *APIClient) CallAPI(path string, method string,
 	// Set post body
 	if postBody != nil {
 		request.Header.Set("Content-Type", "application/json")
-
 		if c.configuration.PatchConfiguration != nil && method == "PATCH" && c.configuration.PatchConfiguration.RemoveOmitEmpty && pathContainsAPI(path, c.configuration.PatchConfiguration.APIs) {
 			processedModel, _ := processModel(postBody)
 			fmt.Println("processed model")
@@ -292,9 +291,9 @@ func copy(data []byte, v interface{}) {
 func processModel(model interface{}) ([]byte, error) {
 	value := reflect.ValueOf(model)
 	// If it's an interface or a pointer, unwrap it.
-    if value.Kind() == reflect.Ptr && value.Elem().Kind() == reflect.Struct {
-        value = value.Elem()
-    }
+	if value.Kind() == reflect.Ptr && value.Elem().Kind() == reflect.Struct {
+		value = value.Elem()
+	}
 	t := value.Type()
 	sf := make([]reflect.StructField, 0)
 	for i := 0; i < t.NumField(); i++ {

--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -17,8 +17,8 @@ import (
 
 // APIClient provides functions for making API requests
 type APIClient struct {
-	client        retryablehttp.Client
-	configuration *Configuration
+	client             retryablehttp.Client
+	configuration      *Configuration
 }
 
 // NewAPIClient creates a new API client
@@ -118,8 +118,16 @@ func (c *APIClient) CallAPI(path string, method string,
 	// Set post body
 	if postBody != nil {
 		request.Header.Set("Content-Type", "application/json")
-		j, _ := json.Marshal(postBody)
-		request.SetBody(ioutil.NopCloser(bytes.NewReader(j)))
+
+		if c.configuration.PatchConfiguration != nil && method == "PATCH" && c.configuration.PatchConfiguration.RemoveOmitEmpty && pathContainsAPI(path, c.configuration.PatchConfiguration.APIs) {
+			processedModel, _ := processModel(postBody)
+			fmt.Println("processed model")
+			fmt.Println(string(processedModel))
+			request.SetBody(ioutil.NopCloser(bytes.NewReader(processedModel)))
+		} else {
+			j, _ := json.Marshal(postBody)
+			request.SetBody(ioutil.NopCloser(bytes.NewReader(j)))
+		}
 	}
 
 	// Set provided headers
@@ -278,4 +286,36 @@ func copy(data []byte, v interface{}) {
 	dataS := string(data)
 
 	reflect.ValueOf(v).Elem().Set(reflect.ValueOf(&dataS))
+}
+
+// process the model to remove omitempty tags on optional properties
+func processModel(model interface{}) ([]byte, error) {
+	value := reflect.ValueOf(model)
+	// If it's an interface or a pointer, unwrap it.
+    if value.Kind() == reflect.Ptr && value.Elem().Kind() == reflect.Struct {
+        value = value.Elem()
+    }
+	t := value.Type()
+	sf := make([]reflect.StructField, 0)
+	for i := 0; i < t.NumField(); i++ {
+		sf = append(sf, t.Field(i))
+		_, ok := t.Field(i).Tag.Lookup("required")
+		if !ok {
+			sf[i].Tag = reflect.StructTag(fmt.Sprintf("json:\"%v\"", strings.Split(t.Field(i).Tag.Get("json"), ",")[0]))
+			continue
+		}
+	}
+	newType := reflect.StructOf(sf)
+	newValue := value.Convert(newType)
+	return json.Marshal(newValue.Interface())
+}
+
+// check if the path contains an API from the PatchConfiguration APIs list
+func pathContainsAPI(path string, APIs []string) bool {
+	for _, item := range APIs {
+		if strings.Contains(path, item) {
+			return true
+		}
+	}
+	return false
 }

--- a/resources/sdk/purecloudgo/templates/configuration.mustache
+++ b/resources/sdk/purecloudgo/templates/configuration.mustache
@@ -21,29 +21,30 @@ import (
 
 // Configuration has settings to configure the SDK
 type Configuration struct {
-	UserName                 string                `json:"userName,omitempty"`
-	Password                 string                `json:"password,omitempty"`
-	APIKeyPrefix             map[string]string     `json:"APIKeyPrefix,omitempty"`
-	APIKey                   map[string]string     `json:"APIKey,omitempty"`
-	OAuthToken               string                `json:"oAuthToken,omitempty"`
-	Timeout                  int                   `json:"timeout,omitempty"`
-	BasePath                 string                `json:"basePath,omitempty"`
-	Host                     string                `json:"host,omitempty"`
-	Scheme                   string                `json:"scheme,omitempty"`
-	AccessToken              string                `json:"accessToken,omitempty"`
-	RefreshToken             string                `json:"refreshToken,omitempty"`
-	ClientID                 string                `json:"clientId,omitempty"`
-	ClientSecret             string                `json:"clientSecret,omitempty"`
-	ShouldRefreshAccessToken bool                  `json:"shouldRefreshAccessToken,omitempty"`
-	RefreshInProgress        int64                 `json:"refreshInProgress,omitempty"`
-	RefreshTokenWaitTime     int                   `json:"refreshTokenWaitTime,omitempty"`
-	DefaultHeader            map[string]string     `json:"defaultHeader,omitempty"`
-	UserAgent                string                `json:"userAgent,omitempty"`
-	APIClient                APIClient             `json:"APIClient,omitempty"`
-	RetryConfiguration       *RetryConfiguration   `json:"retryConfiguration,omitempty"`
-	LoggingConfiguration     *LoggingConfiguration `json:"loggingConfiguration,omitempty"`
-	ConfigFilePath           string                `json:"configFilePath,omitempty"`
-	AutoReloadConfig         bool                  `json:"autoReloadConfig,omitempty"`
+	UserName                                    string                `json:"userName,omitempty"`
+	Password                                    string                `json:"password,omitempty"`
+	APIKeyPrefix                                map[string]string     `json:"APIKeyPrefix,omitempty"`
+	APIKey                                      map[string]string     `json:"APIKey,omitempty"`
+	OAuthToken                                  string                `json:"oAuthToken,omitempty"`
+	Timeout                                     int                   `json:"timeout,omitempty"`
+	BasePath                                    string                `json:"basePath,omitempty"`
+	Host                                        string                `json:"host,omitempty"`
+	Scheme                                      string                `json:"scheme,omitempty"`
+	AccessToken                                 string                `json:"accessToken,omitempty"`
+	RefreshToken                                string                `json:"refreshToken,omitempty"`
+	ClientID                                    string                `json:"clientId,omitempty"`
+	ClientSecret                                string                `json:"clientSecret,omitempty"`
+	ShouldRefreshAccessToken                    bool                  `json:"shouldRefreshAccessToken,omitempty"`
+	RefreshInProgress                           int64                 `json:"refreshInProgress,omitempty"`
+	RefreshTokenWaitTime                        int                   `json:"refreshTokenWaitTime,omitempty"`
+	DefaultHeader                               map[string]string     `json:"defaultHeader,omitempty"`
+	UserAgent                                   string                `json:"userAgent,omitempty"`
+	APIClient                                   APIClient             `json:"APIClient,omitempty"`
+	RetryConfiguration                          *RetryConfiguration   `json:"retryConfiguration,omitempty"`
+	LoggingConfiguration                        *LoggingConfiguration `json:"loggingConfiguration,omitempty"`
+	ConfigFilePath                              string                `json:"configFilePath,omitempty"`
+	AutoReloadConfig                            bool                  `json:"autoReloadConfig,omitempty"`
+	PatchConfiguration                          *PatchConfiguration   `json:"patchConfiguration,omitempty"`
 }
 
 const (
@@ -59,6 +60,17 @@ const (
 	APSouth1     = "https://api.aps1.pure.cloud"
 	USEast2     = "https://api.use2.us-gov-pure.cloud"
 )
+
+func SetPatchConfiguration(patchConfiguration *PatchConfiguration) {
+	instance.PatchConfiguration = &PatchConfiguration{RemoveOmitEmpty: patchConfiguration.RemoveOmitEmpty, APIs: patchConfiguration.APIs}
+	fmt.Println("PatchConfiguration set")
+	fmt.Printf("%#v\n", instance.PatchConfiguration)
+} 
+
+type PatchConfiguration struct {
+	RemoveOmitEmpty bool     `json:"removeOmitEmpty,omitempty"`
+	APIs            []string `json:"apis,omitempty"`
+}
 
 // RetryConfiguration has settings to configure the SDK retry logic
 type RetryConfiguration struct {

--- a/resources/sdk/purecloudgo/templates/configuration.mustache
+++ b/resources/sdk/purecloudgo/templates/configuration.mustache
@@ -21,30 +21,30 @@ import (
 
 // Configuration has settings to configure the SDK
 type Configuration struct {
-	UserName                                    string                `json:"userName,omitempty"`
-	Password                                    string                `json:"password,omitempty"`
-	APIKeyPrefix                                map[string]string     `json:"APIKeyPrefix,omitempty"`
-	APIKey                                      map[string]string     `json:"APIKey,omitempty"`
-	OAuthToken                                  string                `json:"oAuthToken,omitempty"`
-	Timeout                                     int                   `json:"timeout,omitempty"`
-	BasePath                                    string                `json:"basePath,omitempty"`
-	Host                                        string                `json:"host,omitempty"`
-	Scheme                                      string                `json:"scheme,omitempty"`
-	AccessToken                                 string                `json:"accessToken,omitempty"`
-	RefreshToken                                string                `json:"refreshToken,omitempty"`
-	ClientID                                    string                `json:"clientId,omitempty"`
-	ClientSecret                                string                `json:"clientSecret,omitempty"`
-	ShouldRefreshAccessToken                    bool                  `json:"shouldRefreshAccessToken,omitempty"`
-	RefreshInProgress                           int64                 `json:"refreshInProgress,omitempty"`
-	RefreshTokenWaitTime                        int                   `json:"refreshTokenWaitTime,omitempty"`
-	DefaultHeader                               map[string]string     `json:"defaultHeader,omitempty"`
-	UserAgent                                   string                `json:"userAgent,omitempty"`
-	APIClient                                   APIClient             `json:"APIClient,omitempty"`
-	RetryConfiguration                          *RetryConfiguration   `json:"retryConfiguration,omitempty"`
-	LoggingConfiguration                        *LoggingConfiguration `json:"loggingConfiguration,omitempty"`
-	ConfigFilePath                              string                `json:"configFilePath,omitempty"`
-	AutoReloadConfig                            bool                  `json:"autoReloadConfig,omitempty"`
-	PatchConfiguration                          *PatchConfiguration   `json:"patchConfiguration,omitempty"`
+	UserName                 string                `json:"userName,omitempty"`
+	Password                 string                `json:"password,omitempty"`
+	APIKeyPrefix             map[string]string     `json:"APIKeyPrefix,omitempty"`
+	APIKey                   map[string]string     `json:"APIKey,omitempty"`
+	OAuthToken               string                `json:"oAuthToken,omitempty"`
+	Timeout                  int                   `json:"timeout,omitempty"`
+	BasePath                 string                `json:"basePath,omitempty"`
+	Host                     string                `json:"host,omitempty"`
+	Scheme                   string                `json:"scheme,omitempty"`
+	AccessToken              string                `json:"accessToken,omitempty"`
+	RefreshToken             string                `json:"refreshToken,omitempty"`
+	ClientID                 string                `json:"clientId,omitempty"`
+	ClientSecret             string                `json:"clientSecret,omitempty"`
+	ShouldRefreshAccessToken bool                  `json:"shouldRefreshAccessToken,omitempty"`
+	RefreshInProgress        int64                 `json:"refreshInProgress,omitempty"`
+	RefreshTokenWaitTime     int                   `json:"refreshTokenWaitTime,omitempty"`
+	DefaultHeader            map[string]string     `json:"defaultHeader,omitempty"`
+	UserAgent                string                `json:"userAgent,omitempty"`
+	APIClient                APIClient             `json:"APIClient,omitempty"`
+	RetryConfiguration       *RetryConfiguration   `json:"retryConfiguration,omitempty"`
+	LoggingConfiguration     *LoggingConfiguration `json:"loggingConfiguration,omitempty"`
+	ConfigFilePath           string                `json:"configFilePath,omitempty"`
+	AutoReloadConfig         bool                  `json:"autoReloadConfig,omitempty"`
+	PatchConfiguration       *PatchConfiguration   `json:"patchConfiguration,omitempty"`
 }
 
 const (

--- a/resources/sdk/purecloudgo/templates/model.mustache
+++ b/resources/sdk/purecloudgo/templates/model.mustache
@@ -12,7 +12,7 @@ import ({{#imports}}
 // {{classname}}{{#description}} - {{{description}}}{{/description}}
 type {{classname}} struct { {{#vars}}
 	// {{name}}{{#description}} - {{{description}}}{{/description}}
-	{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"`
+	{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"{{#required}} required:"{{required}}"{{/required}}`
 
 {{/vars}}}
 


### PR DESCRIPTION
To use this solution, you can set the `PatchConfiguration` directly on the `Configuration` object or you can use the `platformclientv2.SetPatchConfiguration()` function.

#### Example 1: Setting `PatchConfiguration` directly on the `Configuration` object:

Set `RemoveOmitEmpty` to true and provide a slice of strings containing the APIs you want this logic to affect on.

```
config := platformclientv2.GetDefaultConfiguration()
patchConfig := &platformclientv2.PatchConfiguration{RemoveOmitEmpty: true, APIs: []string{"/api/v2/journey/", "/api/v2/users/"}}
config.PatchConfiguration = patchConfig
```

In the example above, the `omitempty` tags will be removed from optional properties in post bodies on `PATCH /api/v2/journey` endpoints and `PATCH /api/v2/users` endpoints when making a request.

#### Example 2: Setting `PatchConfiguration` using `platformclientv2.SetPatchConfiguration()`:

Or you can set the `PatchConfiguration` anywhere in your code using the `SetPatchConfiguration()` function.

For example, assume a default configuration has been set (so `PatchConfiguration == nil`) and you want to set the `PatchConfiguration` at a later stage. You can do the following:

```
patchConfig := &platformclientv2.PatchConfiguration{RemoveOmitEmpty: true, APIs: []string{"/api/v2/journey/"}}
platformclientv2.SetPatchConfiguration(patchConfig)
```
Similarly, set `RemoveOmitEmpty` to true and provide a slice of strings containing the APIs you want this logic to affect on.

The function `platformclientv2.SetPatchConfiguration()` will set or override the current `PatchConfiguration`.

**Note:** There are some print statements in the code as i find them useful for testing/debugging etc.. 


