### PR TITLE
Removing symlink for webmessagingsdk api_json template

### DIFF
--- a/resources/sdk/webmessagingjava/templates/api_json.mustache
+++ b/resources/sdk/webmessagingjava/templates/api_json.mustache
@@ -1,1 +1,16 @@
-../../../templates/api_json.mustache
+{
+    {{#operations}}{{#operation}}"{{httpMethod}} {{path}}": {
+        "operationId": "{{{operationIdLowerCase}}}",
+        "functionName": "{{{operationId}}}",
+        "signature": "{{{operationId}}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})"{{#hasParams}},{{/hasParams}}{{^hasParams}}{{#returnType}},{{/returnType}}{{/hasParams}}
+        {{#hasParams}}"parameters": [{{#allParams}}
+            {
+                "name": "{{paramName}}",
+                "type": "{{{dataType}}}",
+                "required": "{{#required}}true{{/required}}{{^required}}false{{/required}}"
+            }{{^-last}},{{/-last}}{{/allParams}}
+        ]{{/hasParams}}{{#returnType}}{{#hasParams}},{{/hasParams}}
+        "return": "{{{returnType}}}"{{/returnType}}
+    }{{^-last}},{{/-last}}
+    {{/operation}}{{/operations}}
+}


### PR DESCRIPTION
The other symlinks have already been reverted and this is causing internal build failures.

The other reverts are here - https://github.com/purecloudlabs/platform-client-sdk-common/commit/42e2183b90179b50bf49b8c04210f1875da6789d