### PR TITLE
Refactor UpgradeSdkEnumConverter to cache the result instead of using reflection each time it reads or writes JSON

### DIFF
--- a/resources/sdk/pureclouddotnet-guest/extensions/Client/UpgradeSdkEnumConverter.cs
+++ b/resources/sdk/pureclouddotnet-guest/extensions/Client/UpgradeSdkEnumConverter.cs
@@ -1,99 +1,105 @@
 using System;
-using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
 namespace {{=it.packageName}}.Client
 {
-    class UpgradeSdkEnumConverter : JsonConverter
+    internal class UpgradeSdkEnumConverter : JsonConverter
     {
         // Inspired by http://stackoverflow.com/questions/22752075/how-can-i-ignore-unknown-enum-values-during-json-deserialization
 
         public override bool CanConvert(Type objectType)
         {
-            var type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
+            var type = Nullable.GetUnderlyingType(objectType) ?? objectType;
             return type.IsEnum;
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            var isNullable = IsNullableType(objectType);
-            var enumType = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
+            var typeInfo = EnumTypeSerializationInfo.FromEnumType(objectType);
 
             switch (reader.TokenType)
             {
                 case JsonToken.String:
                     var enumText = reader.Value.ToString();
-
-                    if (!string.IsNullOrEmpty(enumText))
-                    {
-                        var enumMembers = enumType.GetMembers();
-                        string match = null;
-
-                        foreach (var enumMember in enumMembers)
-                        {
-                            var memberAttributes = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false);
-                            if (memberAttributes.Length > 0)
-                            {
-                                var attribute = memberAttributes.FirstOrDefault() as EnumMemberAttribute;
-                                if (string.Equals(attribute.Value, enumText, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    match = enumMember.Name;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (match != null)
-                        {
-                            return Enum.Parse(enumType, match);
-                        }
-                    }
+                    if (typeInfo.ValuesByString.TryGetValue(enumText, out var result)) return result;
                     break;
                 case JsonToken.Integer:
                     var enumVal = Convert.ToInt32(reader.Value);
-                    var values = (int[])Enum.GetValues(enumType);
-                    if (values.Contains(enumVal))
-                    {
-                        return Enum.Parse(enumType, enumVal.ToString());
-                    }
+                    if (typeInfo.ValuesByInt.TryGetValue(enumVal, out result)) return result;
                     break;
             }
 
-            // See if it has a member named "OUTDATED_SDK_VERSION"
-            var names = Enum.GetNames(enumType);
-            var outdatedSdkVersionMemberName = names
-                .FirstOrDefault(n => string.Equals(n, "OUTDATED_SDK_VERSION", StringComparison.OrdinalIgnoreCase));
-
-            // Return parsed "OUTDATED_SDK_VERSION" member
-            return outdatedSdkVersionMemberName != default(string)
-                ? Enum.Parse(enumType, outdatedSdkVersionMemberName)
-                : Activator.CreateInstance(enumType);
+            return typeInfo.DefaultValue;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var enumMembers = value.GetType().GetMembers();
-
-            foreach (var enumMember in enumMembers)
-            {
-                var memberAttributes = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false);
-                if (memberAttributes.Length > 0)
-                {
-                    var attribute = memberAttributes.FirstOrDefault() as EnumMemberAttribute;
-                    if (string.Equals(enumMember.Name, value.ToString(), StringComparison.OrdinalIgnoreCase))
-                    {
-                        writer.WriteValue(attribute.Value);
-                        return;
-                    }
-                }
-            }
+            var typeInfo = EnumTypeSerializationInfo.FromEnumType(value.GetType());
+            if (typeInfo.StringsByValue.TryGetValue(value, out var enumText)) writer.WriteValue(enumText);
         }
 
-        private bool IsNullableType(Type t)
+        private struct EnumTypeSerializationInfo
         {
-            return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+            private static readonly ConcurrentDictionary<Type, EnumTypeSerializationInfo> Cache = new ConcurrentDictionary<Type, EnumTypeSerializationInfo>(1, 31);
+
+            public static EnumTypeSerializationInfo FromEnumType(Type type)
+            {
+                type = Nullable.GetUnderlyingType(type) ?? type;
+                return Cache.GetOrAdd(type, Build);
+            }
+
+            public readonly IReadOnlyDictionary<string, Enum> ValuesByString;
+
+            public readonly IReadOnlyDictionary<int, Enum> ValuesByInt;
+
+            public readonly IReadOnlyDictionary<object, string> StringsByValue;
+
+            public readonly Enum DefaultValue;
+
+            private EnumTypeSerializationInfo(Type type)
+            {
+                Debug.Assert(type.IsEnum);
+                var enumMembers = type.GetFields(BindingFlags.Public | BindingFlags.Static);
+
+                var valuesByString = new Dictionary<string, Enum>(enumMembers.Length, StringComparer.OrdinalIgnoreCase);
+                var valuesByInt = new Dictionary<int, Enum>(enumMembers.Length);
+                var stringsByValue = new Dictionary<object, string>(enumMembers.Length);
+                Enum defaultValue = null;
+
+                foreach (var enumMember in enumMembers)
+                {
+                    var attribute = enumMember.GetCustomAttribute<EnumMemberAttribute>();
+                    if (attribute == null) continue;
+
+                    var enumValue = (Enum)enumMember.GetValue(null);
+
+                    if (attribute.Value == "OUTDATED_SDK_VERSION")
+                    {
+                        defaultValue = enumValue;
+                    }
+                    else
+                    {
+                        valuesByString[attribute.Value] = enumValue;
+                        stringsByValue[enumValue] = attribute.Value;
+
+                        var intValue = Convert.ToInt32(enumValue);
+                        valuesByInt[intValue] = enumValue;
+                    }
+                }
+
+                ValuesByString = valuesByString;
+                ValuesByInt = valuesByInt;
+                StringsByValue = stringsByValue;
+                DefaultValue = defaultValue ?? (Enum)Activator.CreateInstance(type);
+            }
+
+            private static readonly Func<Type, EnumTypeSerializationInfo> Build = t => new EnumTypeSerializationInfo(t);
         }
     }
 }

--- a/resources/sdk/pureclouddotnet/config.json
+++ b/resources/sdk/pureclouddotnet/config.json
@@ -78,6 +78,18 @@
       ],
       "compileScripts": [
         {
+          "type": "node",
+          "path": "processExtensions.js",
+          "args": [
+            "${COMMON_ROOT}/resources/sdk/pureclouddotnet/extensions-test",
+            "${SDK_REPO}/build/src/${DOTNET_NAMESPACE}.Tests",
+            {
+              "$ref": "#/settings/namespace"
+            }
+          ],
+          "failOnError": true
+        },
+        {
           "type": "shell",
           "path": "compile.sh",
           "args": [

--- a/resources/sdk/pureclouddotnet/extensions-test/UpgradeSdkEnumConverterTests.cs
+++ b/resources/sdk/pureclouddotnet/extensions-test/UpgradeSdkEnumConverterTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using {{=it.packageName}}.Client;
+
+namespace {{=it.packageName}}.Tests
+{
+    [TestFixture]
+    public class UpgradeSdkEnumConverterTests
+    {
+        [JsonConverter(typeof(UpgradeSdkEnumConverter))]
+        public enum TestEnum
+        {
+            [EnumMember(Value = "OUTDATED_SDK_VERSION")]
+            OutdatedSdkVersion,
+
+            [EnumMember(Value = "alerting")]
+            Alerting,
+
+            [EnumMember(Value = "delivery-success")]
+            Deliverysuccess,
+
+            [EnumMember(Value = "none")]
+            None
+        }
+
+        [TestCase(0, ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase(1, ExpectedResult = TestEnum.Alerting)]
+        [TestCase(256, ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase(-1, ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        public TestEnum TestReadInt32(int value)
+        {
+            var jValue = new JValue(value);
+            var reader = jValue.CreateReader();
+            var serializer = JsonSerializer.CreateDefault();
+            return serializer.Deserialize<TestEnum>(reader);
+        }
+
+        [TestCase("alerting", ExpectedResult = TestEnum.Alerting)]
+        [TestCase("AlErTiNg", ExpectedResult = TestEnum.Alerting)]
+        [TestCase("delivery-success", ExpectedResult = TestEnum.Deliverysuccess)]
+        [TestCase(nameof(TestEnum.Deliverysuccess), ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase("foo", ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase("", ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        public TestEnum TestReadString(string value)
+        {
+            var jValue = new JValue(value);
+            var reader = jValue.CreateReader();
+            var serializer = JsonSerializer.CreateDefault();
+            return serializer.Deserialize<TestEnum>(reader);
+        }
+
+        [TestCase("alerting", ExpectedResult = TestEnum.Alerting)]
+        [TestCase("", ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase(null, ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        public TestEnum? TestReadStringNullable(string value)
+        {
+            var jValue = value == null ? JValue.CreateNull() : new JValue(value);
+            var reader = jValue.CreateReader();
+            var serializer = JsonSerializer.CreateDefault();
+            return serializer.Deserialize<TestEnum?>(reader);
+        }
+
+        [TestCase(TestEnum.Deliverysuccess, ExpectedResult = "\"delivery-success\"")]
+        [TestCase(256, ExpectedResult = "")]
+        public string TestWrite(TestEnum value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+
+        [TestCase(TestEnum.Deliverysuccess, ExpectedResult = "\"delivery-success\"")]
+        [TestCase(null, ExpectedResult = "null")]
+        public string TestWriteNullable(TestEnum? value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/resources/sdk/pureclouddotnet/extensions/Client/UpgradeSdkEnumConverter.cs
+++ b/resources/sdk/pureclouddotnet/extensions/Client/UpgradeSdkEnumConverter.cs
@@ -1,99 +1,105 @@
 using System;
-using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
 namespace {{=it.packageName}}.Client
 {
-    class UpgradeSdkEnumConverter : JsonConverter
+    internal class UpgradeSdkEnumConverter : JsonConverter
     {
         // Inspired by http://stackoverflow.com/questions/22752075/how-can-i-ignore-unknown-enum-values-during-json-deserialization
 
         public override bool CanConvert(Type objectType)
         {
-            var type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
+            var type = Nullable.GetUnderlyingType(objectType) ?? objectType;
             return type.IsEnum;
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            var isNullable = IsNullableType(objectType);
-            var enumType = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
+            var typeInfo = EnumTypeSerializationInfo.FromEnumType(objectType);
 
             switch (reader.TokenType)
             {
                 case JsonToken.String:
                     var enumText = reader.Value.ToString();
-
-                    if (!string.IsNullOrEmpty(enumText))
-                    {
-                        var enumMembers = enumType.GetMembers();
-                        string match = null;
-
-                        foreach (var enumMember in enumMembers)
-                        {
-                            var memberAttributes = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false);
-                            if (memberAttributes.Length > 0)
-                            {
-                                var attribute = memberAttributes.FirstOrDefault() as EnumMemberAttribute;
-                                if (string.Equals(attribute.Value, enumText, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    match = enumMember.Name;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (match != null)
-                        {
-                            return Enum.Parse(enumType, match);
-                        }
-                    }
+                    if (typeInfo.ValuesByString.TryGetValue(enumText, out var result)) return result;
                     break;
                 case JsonToken.Integer:
                     var enumVal = Convert.ToInt32(reader.Value);
-                    var values = (int[])Enum.GetValues(enumType);
-                    if (values.Contains(enumVal))
-                    {
-                        return Enum.Parse(enumType, enumVal.ToString());
-                    }
+                    if (typeInfo.ValuesByInt.TryGetValue(enumVal, out result)) return result;
                     break;
             }
 
-            // See if it has a member named "OUTDATED_SDK_VERSION"
-            var names = Enum.GetNames(enumType);
-            var outdatedSdkVersionMemberName = names
-                .FirstOrDefault(n => string.Equals(n, "OUTDATED_SDK_VERSION", StringComparison.OrdinalIgnoreCase));
-
-            // Return parsed "OUTDATED_SDK_VERSION" member
-            return outdatedSdkVersionMemberName != default(string)
-                ? Enum.Parse(enumType, outdatedSdkVersionMemberName)
-                : Activator.CreateInstance(enumType);
+            return typeInfo.DefaultValue;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var enumMembers = value.GetType().GetMembers();
-
-            foreach (var enumMember in enumMembers)
-            {
-                var memberAttributes = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false);
-                if (memberAttributes.Length > 0)
-                {
-                    var attribute = memberAttributes.FirstOrDefault() as EnumMemberAttribute;
-                    if (string.Equals(enumMember.Name, value.ToString(), StringComparison.OrdinalIgnoreCase))
-                    {
-                        writer.WriteValue(attribute.Value);
-                        return;
-                    }
-                }
-            }
+            var typeInfo = EnumTypeSerializationInfo.FromEnumType(value.GetType());
+            if (typeInfo.StringsByValue.TryGetValue(value, out var enumText)) writer.WriteValue(enumText);
         }
 
-        private bool IsNullableType(Type t)
+        private struct EnumTypeSerializationInfo
         {
-            return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+            private static readonly ConcurrentDictionary<Type, EnumTypeSerializationInfo> Cache = new ConcurrentDictionary<Type, EnumTypeSerializationInfo>(1, 31);
+
+            public static EnumTypeSerializationInfo FromEnumType(Type type)
+            {
+                type = Nullable.GetUnderlyingType(type) ?? type;
+                return Cache.GetOrAdd(type, Build);
+            }
+
+            public readonly IReadOnlyDictionary<string, Enum> ValuesByString;
+
+            public readonly IReadOnlyDictionary<int, Enum> ValuesByInt;
+
+            public readonly IReadOnlyDictionary<object, string> StringsByValue;
+
+            public readonly Enum DefaultValue;
+
+            private EnumTypeSerializationInfo(Type type)
+            {
+                Debug.Assert(type.IsEnum);
+                var enumMembers = type.GetFields(BindingFlags.Public | BindingFlags.Static);
+
+                var valuesByString = new Dictionary<string, Enum>(enumMembers.Length, StringComparer.OrdinalIgnoreCase);
+                var valuesByInt = new Dictionary<int, Enum>(enumMembers.Length);
+                var stringsByValue = new Dictionary<object, string>(enumMembers.Length);
+                Enum defaultValue = null;
+
+                foreach (var enumMember in enumMembers)
+                {
+                    var attribute = enumMember.GetCustomAttribute<EnumMemberAttribute>();
+                    if (attribute == null) continue;
+
+                    var enumValue = (Enum)enumMember.GetValue(null);
+
+                    if (attribute.Value == "OUTDATED_SDK_VERSION")
+                    {
+                        defaultValue = enumValue;
+                    }
+                    else
+                    {
+                        valuesByString[attribute.Value] = enumValue;
+                        stringsByValue[enumValue] = attribute.Value;
+
+                        var intValue = Convert.ToInt32(enumValue);
+                        valuesByInt[intValue] = enumValue;
+                    }
+                }
+
+                ValuesByString = valuesByString;
+                ValuesByInt = valuesByInt;
+                StringsByValue = stringsByValue;
+                DefaultValue = defaultValue ?? (Enum)Activator.CreateInstance(type);
+            }
+
+            private static readonly Func<Type, EnumTypeSerializationInfo> Build = t => new EnumTypeSerializationInfo(t);
         }
     }
 }

--- a/resources/sdk/pureclouddotnet/templates/AssemblyInfo.mustache
+++ b/resources/sdk/pureclouddotnet/templates/AssemblyInfo.mustache
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("{{packageCopyright}}")]
 [assembly: AssemblyTrademark("{{packageTrademark}}")]
 [assembly: AssemblyCulture("{{packageCulture}}")]
+[assembly: InternalsVisibleTo("{{packageName}}.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
+++ b/resources/sdk/pureclouddotnet/templates/test-csproj.mustache
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -81,6 +82,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SdkTests.cs" />
     <Compile Include="ApiClientTests.cs" />
+    <Compile Include="UpgradeSdkEnumConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
I was profiling an application that uses the Platform Client SDK (but also does many other things,) and I noticed that 25% of objects allocated on the .NET managed heap were coming from `UpgradeSdkEnumConverter`.  It uses reflection to map strings to enum values.

The implementation proposed on this PR caches the mapping of strings to enum values on the first run for each enum type, and then subsequent runs don't allocate any objects on the managed heap.  I didn't intend to make any changes to the functionality, so I added some new unit tests that pass with both the old and proposed implementations.

I wrote some benchmarks with BenchmarkDotNet to quantify the performance impact of the proposed change:
* `ReadJson` - just calls `UpgradeSdkEnumConverter.ReadJson()` (the method I optimized)
* `DeserializeEnum` - calls `JsonConvert.DeserializeObject<Conversation.StateEnum>("\"transmitting\"")`
* `DeserializeConversation` - calls `JsonConvert.DeserializeObject<Conversation>()` with a normal conversation object

The results show no allocation when `ReadJson()` is used alone, and a ~50% reduction in garbage collections when it is used in the context of deserializing a larger object.

#### Before fix:

|                  Method |         Mean |       Error |      StdDev |    Gen0 |   Gen1 | Allocated |
|------------------------ |-------------:|------------:|------------:|--------:|-------:|----------:|
|                ReadJson |   3,181.5 ns |    18.39 ns |    27.53 ns |  0.2174 |      - |    1040 B |
|         DeserializeEnum |  13,573.1 ns |   118.21 ns |   173.27 ns |  1.4038 | 0.0153 |    6617 B |
| DeserializeConversation | 306,949.0 ns | 2,066.34 ns | 3,092.80 ns | 20.9961 | 1.9531 |  100488 B |

#### After fix:

|                  Method |         Mean |        Error |       StdDev |   Gen0 |   Gen1 | Allocated |
|------------------------ |-------------:|-------------:|-------------:|-------:|-------:|----------:|
|                ReadJson |     36.65 ns |     0.602 ns |     0.863 ns |      - |      - |         - |
|         DeserializeEnum |    732.11 ns |    17.020 ns |    25.474 ns | 0.6113 | 0.0057 |    2880 B |
| DeserializeConversation | 93,841.69 ns | 1,260.671 ns | 1,886.914 ns | 9.5215 | 0.8545 |   44960 B |

>  Mean      : Arithmetic mean of all measurements
>  Error     : Half of 99.9% confidence interval
>  StdDev    : Standard deviation of all measurements
>  Gen0      : GC Generation 0 collects per 1000 operations
>  Gen1      : GC Generation 1 collects per 1000 operations
>  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
>  1 ns      : 1 Nanosecond (0.000000001 sec)