### PR TITLE
DEVENGAGE-1323 field serialization opt in

### DIFF
--- a/resources/sdk/purecloudgo/extensions/platformclientv2_test.go
+++ b/resources/sdk/purecloudgo/extensions/platformclientv2_test.go
@@ -142,6 +142,128 @@ func TestValueSerialization(t *testing.T) {
 	}
 }
 
+func TestCustomSerialization1(t *testing.T) {
+	patchBody := Patchactionmap{}
+
+	// Use SetField to trigger custom serialization
+	patchBody.SetField("Id", String("111-111"))
+
+	// These manually set fields won't appear in the output when SetField is used
+	patchBody.Version = Int(1)
+	patchBody.DisplayName = String("manually set display name")
+
+	// Validate serialization
+	j, err := json.Marshal(patchBody)
+	if err != nil {
+		t.Error(err)
+	}
+	s := string(j)
+	expected := `{"id":"111-111"}`
+	if s != expected {
+		t.Log("Patchactionmap did not serialize correctly")
+		t.Logf("Expected: %v", expected)
+		t.Logf("Actual:   %v", s)
+		t.FailNow()
+	}
+}
+
+func TestCustomSerialization2(t *testing.T) {
+	patchBody := Patchactionmap{}
+
+	// These manually set fields won't appear in the output when SetField is used
+	patchBody.Id = String("999-999")
+	patchBody.Version = Int(1)
+	patchBody.DisplayName = String("manually set display name")
+	patchBody.IsActive = Bool(true)
+
+	// Use SetField to trigger custom serialization
+	patchBody.SetField("Id", String("222-222"))
+	patchBody.SetField("Version", Int(2))
+	patchBody.SetField("DisplayName", nil)
+
+	// Validate serialization
+	j, err := json.Marshal(patchBody)
+	if err != nil {
+		t.Error(err)
+	}
+	s := string(j)
+	expected := `{"displayName":null,"id":"222-222","version":2}`
+	if s != expected {
+		t.Log("Patchactionmap did not serialize correctly")
+		t.Logf("Expected: %v", expected)
+		t.Logf("Actual:   %v", s)
+		t.FailNow()
+	}
+}
+
+func TestCustomSerialization3(t *testing.T) {
+	patchBody := Patchactionmap{}
+
+	// These manually set fields won't appear in the output when SetField is used
+	patchBody.Version = Int(1)
+	patchBody.DisplayName = String("manually set display name")
+
+	// Use SetField to trigger custom serialization
+	patchBody.SetField("Id", String("333-333"))
+	patchBody.SetField("Version", Int(3))
+	patchBody.SetField("DisplayName", nil)
+
+	// Use default serialization on nested struct
+	patchAction := Patchaction{}
+	patchAction.ActionTargetId = String("12345")
+	patchAction.IsPacingEnabled = Bool(false)
+	patchAction.MediaType = nil
+	patchBody.SetField("Action", &patchAction)
+
+	// Validate serialization
+	j, err := json.Marshal(patchBody)
+	if err != nil {
+		t.Error(err)
+	}
+	s := string(j)
+	expected := `{"action":{"actionTargetId":"12345","isPacingEnabled":false},"displayName":null,"id":"333-333","version":3}`
+	if s != expected {
+		t.Log("Patchactionmap did not serialize correctly")
+		t.Logf("Expected: %v", expected)
+		t.Logf("Actual:   %v", s)
+		t.FailNow()
+	}
+}
+
+func TestCustomSerialization4(t *testing.T) {
+	patchBody := Patchactionmap{}
+
+	// These manually set fields won't appear in the output when SetField is used
+	patchBody.Version = Int(1)
+	patchBody.DisplayName = String("manually set display name")
+
+	// Use SetField to trigger custom serialization
+	patchBody.SetField("Id", String("444-444"))
+	patchBody.SetField("Version", Int(4))
+	patchBody.SetField("DisplayName", nil)
+
+	// Use custom serialization on nested struct
+	patchAction := Patchaction{}
+	patchAction.SetField("ActionTargetId", String("12345"))
+	patchAction.IsPacingEnabled = Bool(false)
+	patchAction.SetField("MediaType", nil)
+	patchBody.SetField("Action", &patchAction)
+
+	// Validate serialization
+	j, err := json.Marshal(patchBody)
+	if err != nil {
+		t.Error(err)
+	}
+	s := string(j)
+	expected := `{"action":{"actionTargetId":"12345","mediaType":null},"displayName":null,"id":"444-444","version":4}`
+	if s != expected {
+		t.Log("Patchactionmap did not serialize correctly")
+		t.Logf("Expected: %v", expected)
+		t.Logf("Actual:   %v", s)
+		t.FailNow()
+	}
+}
+
 func TestAuthentication(t *testing.T) {
 	err := GetDefaultConfiguration().AuthorizeClientCredentials(config.clientID, config.clientSecret)
 	if err != nil {

--- a/resources/sdk/purecloudgo/templates/README.mustache
+++ b/resources/sdk/purecloudgo/templates/README.mustache
@@ -246,6 +246,37 @@ if err != nil {
 }
 ```
 
+#### PATCH requests and custom serialization
+
+For many PATCH resources, it is necessary for the request to distinguish between the sending application not sending a field and sending the field with no value. The Go SDK applies `omitempty` to all struct properties by default, which results in all properties without a value to be excluded from the resulting JSON object. In other words, it is impossible to send a payload with `{"someProp":null}`.
+
+When making requests that need to distinguish between the client not setting a value and setting it to `nil`, use the `SetField` function on model properties. The property name _must_ be a property on the struct and the value must be a pointer. After constructing the object in this manner, use it in the request as normal. The custom serialization will be applied manually. This is accomplished using a special property named `SetFieldNames` that has been added to every model to support this behavior. Consider the following example:
+
+```go
+patchBody := platformclientv2.Patchactionmap{}
+
+// These manually set fields won't appear in the output when SetField is used, unless overridden using SetField
+patchBody.Id = String("999-999")
+patchBody.Version = Int(1)
+patchBody.DisplayName = String("manually set display name")
+patchBody.IsActive = Bool(true)
+
+// Use SetField to trigger custom serialization
+patchBody.SetField("Id", String("222-222"))
+patchBody.SetField("Version", Int(2))
+patchBody.SetField("DisplayName", nil)
+```
+
+This serializes to the JSON document below. Note that only the properties set using `SetField` are included, and the new values replaced the directly set values. This behavior allowed the `displayName` property to be `null` in the JSON document while omitting properties that weren't explicitly set.
+
+```json
+{
+  "displayName": null,
+  "id": "222-222",
+  "version": 2
+}
+```
+
 
 ## Versioning
 

--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -279,3 +279,33 @@ func copy(data []byte, v interface{}) {
 
 	reflect.ValueOf(v).Elem().Set(reflect.ValueOf(&dataS))
 }
+
+// SetField uses reflection to set a field on the model if the model has a property SetFieldNames, and triggers custom JSON serialization logic to only serialize properties that have been set using this function.
+func SetField(model interface{}, field string, fieldValue interface{}) error {
+	// Get Value object for field
+	target := reflect.ValueOf(model)
+	targetField := reflect.Indirect(target).FieldByName(field)
+	setFieldNamesField := reflect.Indirect(target).FieldByName("SetFieldNames")
+
+	if !setFieldNamesField.IsValid() {
+		return fmt.Errorf("%s does not have SetFieldNames\n", target.Type())
+	}
+
+	// Set value
+	if fieldValue != nil {
+		fieldValueValue := reflect.ValueOf(fieldValue)
+		targetField.Set(fieldValueValue)
+	} else {
+		// Must create a new Value (creates **type) then get its element (*type), which will be nil pointer of the appropriate type
+		targetField.Set(reflect.Indirect(reflect.New(targetField.Type())))
+	}
+
+	// Add field to set field names list
+	if setFieldNamesField.IsNil() {
+		fmt.Println("Init map")
+		setFieldNamesField.Set(reflect.ValueOf(make(map[string]bool)))
+	}
+	setFieldNamesField.Interface().(map[string]bool)[field] = true
+
+	return nil
+}

--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -280,32 +280,23 @@ func copy(data []byte, v interface{}) {
 	reflect.ValueOf(v).Elem().Set(reflect.ValueOf(&dataS))
 }
 
-// SetField uses reflection to set a field on the model if the model has a property SetFieldNames, and triggers custom JSON serialization logic to only serialize properties that have been set using this function.
-func SetField(model interface{}, field string, fieldValue interface{}) error {
-	// Get Value object for field
-	target := reflect.ValueOf(model)
-	targetField := reflect.Indirect(target).FieldByName(field)
-	setFieldNamesField := reflect.Indirect(target).FieldByName("SetFieldNames")
-
-	if !setFieldNamesField.IsValid() {
-		return fmt.Errorf("%s does not have SetFieldNames\n", target.Type())
+func getFieldName(t reflect.Type, field string) string {
+	// Find JSON prop name
+	structField, ok := t.Elem().FieldByName(field)
+	if ok {
+		tag := structField.Tag.Get("json")
+		if tag != "" {
+			tagParts := strings.Split(tag, ",")
+			if len(tagParts) > 0 {
+				return tagParts[0]
+			}
+		}
 	}
 
-	// Set value
-	if fieldValue != nil {
-		fieldValueValue := reflect.ValueOf(fieldValue)
-		targetField.Set(fieldValueValue)
-	} else {
-		// Must create a new Value (creates **type) then get its element (*type), which will be nil pointer of the appropriate type
-		targetField.Set(reflect.Indirect(reflect.New(targetField.Type())))
-	}
+	return field
+}
 
-	// Add field to set field names list
-	if setFieldNamesField.IsNil() {
-		fmt.Println("Init map")
-		setFieldNamesField.Set(reflect.ValueOf(make(map[string]bool)))
-	}
-	setFieldNamesField.Interface().(map[string]bool)[field] = true
-
-	return nil
+// toTime is a helper function for models to prevent a static import of the "time" package duplicating dynamic imports determined by the codegen process
+func toTime(o interface{}) *time.Time {
+	return o.(*time.Time)
 }

--- a/resources/sdk/purecloudgo/templates/model.mustache
+++ b/resources/sdk/purecloudgo/templates/model.mustache
@@ -5,7 +5,6 @@ import ({{#imports}}
 	"github.com/leekchan/timeutil"
 	"reflect"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -17,17 +16,61 @@ type {{classname}} struct {
 	SetFieldNames map[string]bool `json:"-"`{{#vars}}
 	// {{name}}{{#description}} - {{{description}}}{{/description}}
 	{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"`
-
 {{/vars}}}
 
+// SetField uses reflection to set a field on the model if the model has a property SetFieldNames, and triggers custom JSON serialization logic to only serialize properties that have been set using this function.
+func (o *{{classname}}) SetField(field string, fieldValue interface{}) {
+	// Get Value object for field
+	target := reflect.ValueOf(o)
+	targetField := reflect.Indirect(target).FieldByName(field)
+
+	// Set value
+	if fieldValue != nil {
+		targetField.Set(reflect.ValueOf(fieldValue))
+	} else {
+		// Must create a new Value (creates **type) then get its element (*type), which will be nil pointer of the appropriate type
+		x := reflect.Indirect(reflect.New(targetField.Type()))
+		targetField.Set(x)
+	}
+
+	// Add field to set field names list
+	if o.SetFieldNames == nil {
+		o.SetFieldNames = make(map[string]bool)
+	}
+	o.SetFieldNames[field] = true
+}
+
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
-	val := reflect.ValueOf(o)
+	// Special processing to dynamically construct object using only field names that have been set using SetField. This generates payloads suitable for use with PATCH API endpoints.
 	if len(o.SetFieldNames) > 0 {
+		// Get reflection Value
+		val := reflect.ValueOf(o)
+
+		// Known field names that require type overrides
+		dateTimeFields := []string{ {{#vars}}{{#isDateTime}}{{^vendorExtensions.x-local-date-time}}"{{name}}",{{/vendorExtensions.x-local-date-time}}{{/isDateTime}}{{/vars}} }
+		localDateTimeFields := []string{ {{#vars}}{{#isDateTime}}{{#vendorExtensions.x-local-date-time}}"{{name}}",{{/vendorExtensions.x-local-date-time}}{{/isDateTime}}{{/vars}} }
+		dateFields := []string{ {{#vars}}{{^isDateTime}}{{#isDate}}"{{name}}",{{/isDate}}{{/isDateTime}}{{/vars}} }
+
+		// Construct object
 		newObj := make(map[string]interface{})
 		for fieldName := range o.SetFieldNames {
-			newObj[fieldName] = val.FieldByName(fieldName).Interface()
+			// Get initial field value
+			fieldValue := val.FieldByName(fieldName).Interface()
+
+			// Apply value formatting overrides
+			if contains(dateTimeFields, fieldName) {
+				fieldValue = timeutil.Strftime(toTime(fieldValue), "%Y-%m-%dT%H:%M:%S.%fZ")
+			} else if contains(localDateTimeFields, fieldName) {
+				fieldValue = timeutil.Strftime(toTime(fieldValue), "%Y-%m-%dT%H:%M:%S.%f")
+			} else if contains(dateFields, fieldName) {
+				fieldValue = timeutil.Strftime(toTime(fieldValue), "%Y-%m-%d")
+			}
+
+			// Assign value to field using JSON tag name
+			newObj[getFieldName(reflect.TypeOf(&o), fieldName)] = fieldValue
 		}
 
+		// Marshal and return dynamically constructed interface
 		return json.Marshal(newObj)
 	}
 

--- a/resources/sdk/purecloudgo/templates/model.mustache
+++ b/resources/sdk/purecloudgo/templates/model.mustache
@@ -3,20 +3,34 @@ package {{packageName}}
 import ({{#imports}}
 	"{{import}}"{{/imports}}
 	"github.com/leekchan/timeutil"
+	"reflect"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 )
 {{#model}}
 
 // {{classname}}{{#description}} - {{{description}}}{{/description}}
-type {{classname}} struct { {{#vars}}
+type {{classname}} struct { 
+	// SetFieldNames defines the list of fields to use for controlled JSON serialization
+	SetFieldNames map[string]bool `json:"-"`{{#vars}}
 	// {{name}}{{#description}} - {{{description}}}{{/description}}
 	{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"`
 
 {{/vars}}}
 
-func (o *{{classname}}) MarshalJSON() ([]byte, error) {
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+	val := reflect.ValueOf(o)
+	if len(o.SetFieldNames) > 0 {
+		newObj := make(map[string]interface{})
+		for fieldName := range o.SetFieldNames {
+			newObj[fieldName] = val.FieldByName(fieldName).Interface()
+		}
+
+		return json.Marshal(newObj)
+	}
+
 	// Redundant initialization to avoid unused import errors for models with no Time values
 	_  = timeutil.Timedelta{}
 	type Alias {{classname}}
@@ -42,14 +56,14 @@ func (o *{{classname}}) MarshalJSON() ([]byte, error) {
 		{{name}} *string `json:"{{baseName}},omitempty"`
 		{{/isDate}}{{^isDate}}
 		{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"`
-		{{/isDate}}{{/isDateTime}}{{/vars}}*Alias
+		{{/isDate}}{{/isDateTime}}{{/vars}}Alias
 	}{ {{#vars}}{{#isDateTime}}
 		{{name}}: {{name}},
 		{{/isDateTime}}{{^isDateTime}}{{#isDate}}
 		{{name}}: {{name}},
 		{{/isDate}}{{^isDate}}
 		{{name}}: o.{{name}},
-		{{/isDate}}{{/isDateTime}}{{/vars}}Alias:    (*Alias)(o),
+		{{/isDate}}{{/isDateTime}}{{/vars}}Alias:    (Alias)(o),
 	})
 }
 


### PR DESCRIPTION
Adds a helper function to models in the Go SDK to manually control which properties are serialized, regardless of their value (including nil). Example:

```go
	patchBody := platformclientv2.Patchactionmap{}
	patchBody.SetField("Id", platformclientv2.String("777-777"))
	patchBody.SetField("Version", platformclientv2.Int(7))
	patchBody.SetField("DisplayName", nil)

	patchAction := platformclientv2.Patchaction{}
	patchAction.SetField("ActionTargetId", platformclientv2.String("12345"))
	patchBody.SetField("Action", &patchAction)
```

yields:

```json
{
  "action": {
    "actionTargetId": "12345"
  },
  "displayName": null,
  "id": "777-777",
  "version": 7
}
```

This allows applications to explicitly construct request objects that will be serialized exactly the way they are created, ignoring the default serialization rules (i.e. not distinguishing between a field not being set at all vs. being set with a nil value). 