### PR TITLE
Fix unintentional change in behavior of UpgradeSdkEnumConverter serializing OUTDATED_SDK_VERSION

### DIFF
--- a/resources/sdk/pureclouddotnet/extensions-test/UpgradeSdkEnumConverterTests.cs
+++ b/resources/sdk/pureclouddotnet/extensions-test/UpgradeSdkEnumConverterTests.cs
@@ -41,6 +41,7 @@ namespace {{=it.packageName}}.Tests
         [TestCase("AlErTiNg", ExpectedResult = TestEnum.Alerting)]
         [TestCase("delivery-success", ExpectedResult = TestEnum.Deliverysuccess)]
         [TestCase(nameof(TestEnum.Deliverysuccess), ExpectedResult = TestEnum.OutdatedSdkVersion)]
+        [TestCase("OUTDATED_SDK_VERSION", ExpectedResult = TestEnum.OutdatedSdkVersion)]
         [TestCase("foo", ExpectedResult = TestEnum.OutdatedSdkVersion)]
         [TestCase("", ExpectedResult = TestEnum.OutdatedSdkVersion)]
         public TestEnum TestReadString(string value)
@@ -63,6 +64,7 @@ namespace {{=it.packageName}}.Tests
         }
 
         [TestCase(TestEnum.Deliverysuccess, ExpectedResult = "\"delivery-success\"")]
+        [TestCase(TestEnum.OutdatedSdkVersion, ExpectedResult = "\"OUTDATED_SDK_VERSION\"")]
         [TestCase(256, ExpectedResult = "")]
         public string TestWrite(TestEnum value)
         {
@@ -70,6 +72,7 @@ namespace {{=it.packageName}}.Tests
         }
 
         [TestCase(TestEnum.Deliverysuccess, ExpectedResult = "\"delivery-success\"")]
+        [TestCase(TestEnum.OutdatedSdkVersion, ExpectedResult = "\"OUTDATED_SDK_VERSION\"")]
         [TestCase(null, ExpectedResult = "null")]
         public string TestWriteNullable(TestEnum? value)
         {

--- a/resources/sdk/pureclouddotnet/extensions/Client/UpgradeSdkEnumConverter.cs
+++ b/resources/sdk/pureclouddotnet/extensions/Client/UpgradeSdkEnumConverter.cs
@@ -82,6 +82,7 @@ namespace {{=it.packageName}}.Client
                     if (attribute.Value == "OUTDATED_SDK_VERSION")
                     {
                         defaultValue = enumValue;
+                        stringsByValue[enumValue] = attribute.Value;
                     }
                     else
                     {


### PR DESCRIPTION
I recently noticed that my change on PR #499 caused an unintentional change in behavior in cases where it writes `OUTDATED_SDK_VERSION` as a value to JSON.   Before that PR, it would write `"OUTDATED_SDK_VERSION"`, but after that PR it would write nothing.   This PR keeps the optimization from PR #499 but restores the original behavior in this case.

This is a fringe use case -- it should be unusual to serialize the actual value `OUTDATED_SDK_VERSION`, but that PR was not intended to change any behavior.  It caused a problem in a very specific use case in my application.