### PR TITLE
add proxy capabilities for cli

### DIFF
--- a/resources/sdk/clisdkclient/extensions/cmd/proxy/proxy.go
+++ b/resources/sdk/clisdkclient/extensions/cmd/proxy/proxy.go
@@ -1,0 +1,95 @@
+package proxy
+
+import (
+        "encoding/json"
+        "fmt"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/logger"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/utils"
+        "github.com/spf13/cobra"
+        "io/ioutil"
+        "os"
+)
+
+func Cmdproxy() *cobra.Command {
+        utils.AddFlag(setProxyFileCmd.Flags(), "string", "file", "", "proxy configuration in file")
+		setProxyFileCmd.AddCommand(disableCmd)
+        return setProxyFileCmd
+}
+
+var setProxyFileCmd = &cobra.Command{
+        Use:   "proxy",
+        Short: "Manages the proxy for the CLI",
+        Long:  `Manages the proxy for the CLI`,
+        Args:  cobra.NoArgs,
+
+        Run: func(cmd *cobra.Command, args []string) {
+                profileName, _ := cmd.Root().Flags().GetString("profile")
+                c, err := config.GetConfig(profileName)
+
+                proxyconfig := ResolveConfigurationFlag(cmd)
+                if err != nil {
+                        logger.Fatal(err)
+                }
+                err = config.UpdateProxyConfiguration(c, proxyconfig)
+                if err != nil {
+                        logger.Fatal(err)
+                }
+        },
+}
+
+var disableCmd = &cobra.Command{
+		Use:   "disable",
+		Short: "disables proxy",
+		Long:  `disables proxy`,
+		Args:  cobra.NoArgs,
+
+		Run: func(cmd *cobra.Command, args []string) {
+				profileName, _ := cmd.Root().Flags().GetString("profile")
+				c, err := config.GetConfig(profileName)
+
+				if err != nil {
+						logger.Fatal(err)
+				}
+				err = config.UpdateProxyConfiguration(c, nil)
+                if err != nil {
+                        logger.Fatal(err)
+                }
+		},
+}
+
+func ResolveConfigurationFlag(cmd *cobra.Command) *(config.ProxyConfiguration) {
+        fileName, err := cmd.Flags().GetString("file")
+        if err != nil {
+                logger.Fatal(err)
+        }
+
+        if fileName != "" {
+                return convertToJSON(fileName)
+        }
+
+        for _, command := range cmd.Commands() {
+                files, _ := command.Flags().GetString("file")
+                if files != "" {
+                        return convertToJSON(files)
+                }
+        }
+        return nil
+}
+
+func convertToJSON(fileName string) *(config.ProxyConfiguration) {
+        jsonFile, err := os.Open(fileName)
+        if err != nil {
+                logger.Fatal(fmt.Sprintf("Unable to open file %s.", fileName), err)
+        }
+
+        // defer the closing of our jsonFile so that we can parse it later on
+        defer jsonFile.Close()
+
+        fileContent, _ := ioutil.ReadAll(jsonFile)
+        proxyconf := config.ProxyConfiguration{}
+        if err := json.Unmarshal(fileContent, &proxyconf); err != nil {
+                panic(err)
+        }
+        return &proxyconf
+}

--- a/resources/sdk/clisdkclient/extensions/config/config.go
+++ b/resources/sdk/clisdkclient/extensions/config/config.go
@@ -1,404 +1,476 @@
 package config
 
 import (
-	"fmt"
-	"os"
+        "fmt"
+        "os"
 
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
 
-	"strings"
+        "strings"
 
-	"github.com/spf13/viper"
+        "github.com/spf13/viper"
+
+        "encoding/json"
 )
 
 type Configuration interface {
-	ProfileName() string
-	Environment() string
-	ClientID() string
-	ClientSecret() string
-	RedirectURI() string
-	OAuthTokenData() string
-	AccessToken() string
-	LogFilePath() string
-	SecureLoginEnabled() bool
-	LoggingEnabled() bool
-	AutoPaginationEnabled() bool
-	fmt.Stringer
+        ProfileName() string
+        Environment() string
+        ClientID() string
+        ClientSecret() string
+        RedirectURI() string
+        OAuthTokenData() string
+        AccessToken() string
+        LogFilePath() string
+        SecureLoginEnabled() bool
+        LoggingEnabled() bool
+        AutoPaginationEnabled() bool
+        ProxyConfiguration() *ProxyConfiguration
+        fmt.Stringer
 }
 
 type configuration struct {
-	profileName           string
-	environment           string
-	clientID              string
-	clientSecret          string
-	secureLoginEnabled    bool
-	redirectURI           string
-	oAuthTokenData        string
-	accessToken           string
-	logFilePath           string
-	loggingEnabled        bool
-	autoPaginationEnabled bool
+        profileName           string
+        environment           string
+        clientID              string
+        clientSecret          string
+        secureLoginEnabled    bool
+        redirectURI           string
+        oAuthTokenData        string
+        accessToken           string
+        logFilePath           string
+        loggingEnabled        bool
+        autoPaginationEnabled bool
+        proxyConfiguration    *ProxyConfiguration
+}
+
+// ProxyConfiguration has settings to configure the SDK Proxy logic
+type ProxyConfiguration struct {
+        Protocol string `json:"protocol,omitempty"`
+        Host     string `json:"host,omitempty"`
+        Port     string `json:"port,omitempty"`
+        Auth     *Auth  `json:"auth,omitempty"`
+}
+
+type Auth struct {
+        UserName string `json:"username,omitempty"`
+        Password string `json:"password,omitempty"`
 }
 
 var (
-	Environment    string
-	ClientId       string
-	ClientSecret   string
-	AccessToken    string
-	regionMappings = map[string]string{
-		"us-east-1":      "mypurecloud.com",
-		"eu-west-1":      "mypurecloud.ie",
-		"ap-southeast-2": "mypurecloud.com.au",
-		"ap-northeast-1": "mypurecloud.jp",
-		"eu-central-1":   "mypurecloud.de",
-		"us-west-2":      "usw2.pure.cloud",
-		"ca-central-1":   "cac1.pure.cloud",
-		"ap-northeast-2": "apne2.pure.cloud",
-		"eu-west-2":      "euw2.pure.cloud",
-		"ap-south-1":     "aps1.pure.cloud",
-		"us-east-2":      "use2.us-gov-pure.cloud",
-		"sa-east-1":      "sae1.pure.cloud",
-	}
+        Environment    string
+        ClientId       string
+        ClientSecret   string
+        AccessToken    string
+        regionMappings = map[string]string{
+                "us-east-1":      "mypurecloud.com",
+                "eu-west-1":      "mypurecloud.ie",
+                "ap-southeast-2": "mypurecloud.com.au",
+                "ap-northeast-1": "mypurecloud.jp",
+                "eu-central-1":   "mypurecloud.de",
+                "us-west-2":      "usw2.pure.cloud",
+                "ca-central-1":   "cac1.pure.cloud",
+                "ap-northeast-2": "apne2.pure.cloud",
+                "eu-west-2":      "euw2.pure.cloud",
+                "ap-south-1":     "aps1.pure.cloud",
+                "us-east-2":      "use2.us-gov-pure.cloud",
+                "sa-east-1":      "sae1.pure.cloud",
+        }
 )
 
 //ProfileName is the name of the profile being used to run the CLI
 func (c *configuration) ProfileName() string {
-	return c.profileName
+        return c.profileName
 }
 
 //ClientID is the OAuth client id used by the OAuth Client
 func (c *configuration) ClientID() string {
-	if ClientId != "" {
-		return ClientId
-	}
+        if ClientId != "" {
+                return ClientId
+        }
 
-	return viper.GetString(fmt.Sprintf("%s.client_credentials", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.client_credentials", c.profileName))
 }
 
 //ClientSecret is the OAuth client secret used by the OAuth Client
 func (c *configuration) ClientSecret() string {
-	if ClientSecret != "" {
-		return ClientSecret
-	}
+        if ClientSecret != "" {
+                return ClientSecret
+        }
 
-	return viper.GetString(fmt.Sprintf("%s.client_secret", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.client_secret", c.profileName))
 }
 
 func (c *configuration) AccessToken() string {
-	if AccessToken != "" {
-		return AccessToken
-	}
+        if AccessToken != "" {
+                return AccessToken
+        }
 
-	return viper.GetString(fmt.Sprintf("%s.access_token", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.access_token", c.profileName))
 }
 
 func (c *configuration) SecureLoginEnabled() bool {
-	return viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", c.profileName))
+        return viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", c.profileName))
 }
 
 func (c *configuration) RedirectURI() string {
-	return viper.GetString(fmt.Sprintf("%s.redirect_uri", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.redirect_uri", c.profileName))
 }
 
 //OAuthTokenData is the raw OAuth token data returned from the login API call combined with the access token expiry timestamp
 func (c *configuration) OAuthTokenData() string {
-	return viper.GetString(fmt.Sprintf("%s.oauth_token_data", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.oauth_token_data", c.profileName))
 }
 
 //Environment is the Genesys Cloud Environment the CLI will talk to
 func (c *configuration) Environment() string {
-	if Environment != "" {
-		return MapEnvironment(Environment)
-	}
+        if Environment != "" {
+                return MapEnvironment(Environment)
+        }
 
-	return MapEnvironment(viper.GetString(fmt.Sprintf("%s.environment", c.profileName)))
+        return MapEnvironment(viper.GetString(fmt.Sprintf("%s.environment", c.profileName)))
 }
 
 func MapEnvironment(env string) string {
-	if env != "localhost" && !strings.Contains(env, ".") {
-		basePath, ok := regionMappings[env]
-		if !ok {
-			fmt.Println("Invalid AWS region:", env)
-			os.Exit(1)
-		}
-		return basePath
-	}
+        if env != "localhost" && !strings.Contains(env, ".") {
+                basePath, ok := regionMappings[env]
+                if !ok {
+                        fmt.Println("Invalid AWS region:", env)
+                        os.Exit(1)
+                }
+                return basePath
+        }
 
-	return env
+        return env
 }
 
 //LogFilePath is the path the CLI logs to if an override has been specified
 func (c *configuration) LogFilePath() string {
-	return viper.GetString(fmt.Sprintf("%s.log_file_path", c.profileName))
+        return viper.GetString(fmt.Sprintf("%s.log_file_path", c.profileName))
 }
 
 //LoggingEnabled shows whether logging is enabled or disabled for the CLI
 func (c *configuration) LoggingEnabled() bool {
-	return viper.GetBool(fmt.Sprintf("%s.logging_enabled", c.profileName))
+        return viper.GetBool(fmt.Sprintf("%s.logging_enabled", c.profileName))
 }
 
 //AutoPagination shows whether auto-pagination is enabled or disabled for the CLI
 func (c *configuration) AutoPaginationEnabled() bool {
-	return viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", c.profileName))
+        return viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", c.profileName))
+}
+
+//ProfileName is the name of the profile being used to run the CLI
+func (c *configuration) ProxyConfiguration() *ProxyConfiguration {
+        return c.proxyConfiguration
+}
+
+func getProxyConfig(profileName string) *ProxyConfiguration {
+        // proxy
+        proxyI := viper.Get(fmt.Sprintf("%s.proxy", profileName))
+        if &proxyI != nil {
+                jsonbody, err := json.Marshal(proxyI)
+                if err != nil {
+                        return nil
+                }
+                proxyconf := ProxyConfiguration{}
+                if err := json.Unmarshal(jsonbody, &proxyconf); err != nil {
+                        return nil
+                }
+                return &proxyconf
+        } else {
+                return nil
+        }
 }
 
 func (c *configuration) String() string {
-	return fmt.Sprintf(`{"profileName": "%s", "environment": "%s", "logFilePath": "%s", "loggingEnabled": "%v", "clientName": "%s", "clientSecret": "%s", "secureLoginEnabled": "%v", "redirectURI": "%s", "accessToken": "%s", "autoPaginationEnabled": "%v"}`, c.ProfileName(), c.Environment(), c.LogFilePath(), c.LoggingEnabled(), c.ClientID(), c.ClientSecret(), c.SecureLoginEnabled(), c.RedirectURI(), c.AccessToken(), c.AutoPaginationEnabled())
+        return fmt.Sprintf(`{"profileName": "%s", "environment": "%s", "logFilePath": "%s", "loggingEnabled": "%v", "clientName": "%s", "clientSecret": "%s", "secureLoginEnabled": "%v", "redirectURI": "%s", "accessToken": "%s", "autoPaginationEnabled": "%v","proxyConfiguration": "%v"}`, c.ProfileName(), c.Environment(), c.LogFilePath(), c.LoggingEnabled(), c.ClientID(), c.ClientSecret(), c.SecureLoginEnabled(), c.RedirectURI(), c.AccessToken(), c.AutoPaginationEnabled(), getProxyConfigString(c.ProfileName()))
+}
+
+func getProxyConfigString(profileName string) string {
+	// proxy
+	proxyI := viper.Get(fmt.Sprintf("%s.proxy", profileName))
+	if &proxyI != nil {
+			jsonbody, err := json.Marshal(proxyI)
+			if err != nil {
+					return ""
+			}
+			return string(jsonbody)
+	} else {
+			return ""
+	}
 }
 
 func applyEnvironmentVariableOverrides() {
-	environment := os.Getenv("GENESYSCLOUD_REGION")
-	if environment != "" && Environment == "" {
-		Environment = environment
-	}
-	clientId := os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID")
-	if clientId != "" && ClientId == "" {
-		ClientId = clientId
-	}
-	clientSecret := os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET")
-	if clientSecret != "" && ClientSecret == "" {
-		ClientSecret = clientSecret
-	}
-	accessToken := os.Getenv("GENESYSCLOUD_ACCESS_TOKEN")
-	if accessToken != "" && AccessToken == "" {
-		AccessToken = accessToken
-	}
+        environment := os.Getenv("GENESYSCLOUD_REGION")
+        if environment != "" && Environment == "" {
+                Environment = environment
+        }
+        clientId := os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID")
+        if clientId != "" && ClientId == "" {
+                ClientId = clientId
+        }
+        clientSecret := os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET")
+        if clientSecret != "" && ClientSecret == "" {
+                ClientSecret = clientSecret
+        }
+        accessToken := os.Getenv("GENESYSCLOUD_ACCESS_TOKEN")
+        if accessToken != "" && AccessToken == "" {
+                AccessToken = accessToken
+        }
 }
 
 //GetConfig retrieves the config for the current profile
 func GetConfig(profileName string) (Configuration, error) {
-	applyEnvironmentVariableOverrides()
+        applyEnvironmentVariableOverrides()
 
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			if OverridesApplied() {
-				return &configuration{
-					profileName:  profileName,
-					clientID:     ClientId,
-					clientSecret: ClientSecret,
-					accessToken:  AccessToken,
-					environment:  Environment,
-				}, nil
-			}
-			homeDir, _ := os.UserHomeDir()
-			configDir := fmt.Sprintf("%s/.gc/config.toml", homeDir)
-			return nil, fmt.Errorf(`Failed to load config file in "%s". Please use "gc profiles" command to configure the CLI profiles`, configDir)
-		} else {
-			return nil, fmt.Errorf("Error reading config file, %s", err)
-		}
-	}
+        if err := viper.ReadInConfig(); err != nil {
+                if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+                        if OverridesApplied() {
+                                return &configuration{
+                                        profileName:  profileName,
+                                        clientID:     ClientId,
+                                        clientSecret: ClientSecret,
+                                        accessToken:  AccessToken,
+                                        environment:  Environment,
+                                }, nil
+                        }
+                        homeDir, _ := os.UserHomeDir()
+                        configDir := fmt.Sprintf("%s/.gc/config.toml", homeDir)
+                        return nil, fmt.Errorf(`Failed to load config file in "%s". Please use "gc profiles" command to configure the CLI profiles`, configDir)
+                } else {
+                        return nil, fmt.Errorf("Error reading config file, %s", err)
+                }
+        }
 
-	profile := viper.GetViper().Get(profileName)
+        profile := viper.GetViper().Get(profileName)
 
-	if profile == nil {
-		return nil, fmt.Errorf("The profile named %s passed can not be located in the config file.", profileName)
-	}
+        if profile == nil {
+                return nil, fmt.Errorf("The profile named %s passed can not be located in the config file.", profileName)
+        }
 
-	return &configuration{profileName: profileName,
-		clientID:              viper.GetString(fmt.Sprintf("%s.client_credentials", profileName)),
-		clientSecret:          viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
-		redirectURI:           viper.GetString(fmt.Sprintf("%s.redirect_uri", profileName)),
-		environment:           viper.GetString(fmt.Sprintf("%s.environment", profileName)),
-		oAuthTokenData:        viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
-		accessToken:           viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
-		logFilePath:           viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
-		loggingEnabled:        viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
-		autoPaginationEnabled: viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)),
-		secureLoginEnabled:    viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", profileName)),
-	}, nil
+        return &configuration{profileName: profileName,
+                clientID:              viper.GetString(fmt.Sprintf("%s.client_credentials", profileName)),
+                clientSecret:          viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
+                redirectURI:           viper.GetString(fmt.Sprintf("%s.redirect_uri", profileName)),
+                environment:           viper.GetString(fmt.Sprintf("%s.environment", profileName)),
+                oAuthTokenData:        viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
+                accessToken:           viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
+                logFilePath:           viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
+                loggingEnabled:        viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
+                autoPaginationEnabled: viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)),
+                secureLoginEnabled:    viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", profileName)),
+                proxyConfiguration:    getProxyConfig(profileName),
+        }, nil
 }
 
 func ListConfigs() ([]configuration, error) {
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			homeDir, _ := os.UserHomeDir()
-			configDir := fmt.Sprintf("%s/.gc/config.toml", homeDir)
-			return nil, fmt.Errorf(`Failed to load config file in "%s". Please use "gc profiles" command to configure the CLI profiles`, configDir)
-		} else {
-			return nil, fmt.Errorf("Error reading config file, %s", err)
-		}
-	}
+        if err := viper.ReadInConfig(); err != nil {
+                if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+                        homeDir, _ := os.UserHomeDir()
+                        configDir := fmt.Sprintf("%s/.gc/config.toml", homeDir)
+                        return nil, fmt.Errorf(`Failed to load config file in "%s". Please use "gc profiles" command to configure the CLI profiles`, configDir)
+                } else {
+                        return nil, fmt.Errorf("Error reading config file, %s", err)
+                }
+        }
 
-	settings := viper.GetViper().AllSettings()
-	if settings == nil || len(settings) == 0 {
-		return nil, fmt.Errorf("No profiles have been found.")
-	}
+        settings := viper.GetViper().AllSettings()
+        if settings == nil || len(settings) == 0 {
+                return nil, fmt.Errorf("No profiles have been found.")
+        }
 
-	configurations := make([]configuration, 0)
-	for profileName, _ := range settings {
-		configurations = append(configurations, configuration{
-			profileName:           profileName,
-			clientID:              viper.GetString(fmt.Sprintf("%s.client_credentials", profileName)),
-			clientSecret:          viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
-			redirectURI:           viper.GetString(fmt.Sprintf("%s.redirect_uri", profileName)),
-			environment:           viper.GetString(fmt.Sprintf("%s.environment", profileName)),
-			oAuthTokenData:        viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
-			accessToken:           viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
-			logFilePath:           viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
-			loggingEnabled:        viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
-			autoPaginationEnabled: viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)),
-			secureLoginEnabled:    viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", profileName)),
-		})
-	}
+        configurations := make([]configuration, 0)
+        for profileName, _ := range settings {
+                configurations = append(configurations, configuration{
+                        profileName:           profileName,
+                        clientID:              viper.GetString(fmt.Sprintf("%s.client_credentials", profileName)),
+                        clientSecret:          viper.GetString(fmt.Sprintf("%s.client_secret", profileName)),
+                        redirectURI:           viper.GetString(fmt.Sprintf("%s.redirect_uri", profileName)),
+                        environment:           viper.GetString(fmt.Sprintf("%s.environment", profileName)),
+                        oAuthTokenData:        viper.GetString(fmt.Sprintf("%s.oauth_token_data", profileName)),
+                        accessToken:           viper.GetString(fmt.Sprintf("%s.access_token", profileName)),
+                        logFilePath:           viper.GetString(fmt.Sprintf("%s.log_file_path", profileName)),
+                        loggingEnabled:        viper.GetBool(fmt.Sprintf("%s.logging_enabled", profileName)),
+                        autoPaginationEnabled: viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)),
+                        secureLoginEnabled:    viper.GetBool(fmt.Sprintf("%s.secure_login_enabled", profileName)),
+                        proxyConfiguration:    getProxyConfig(profileName),
+                })
+        }
 
-	return configurations, nil
+        return configurations, nil
 }
 
 func SaveConfig(c Configuration) error {
-	return writeConfig(c, nil, "", nil, nil)
+        return writeConfig(c, nil, "", nil, nil)
 }
 
 func UpdateOAuthToken(c Configuration, data *models.OAuthTokenData) error {
-	return updateConfig(configuration{
-		profileName:    c.ProfileName(),
-		oAuthTokenData: data.String(),
-	}, nil, nil, nil)
+        return updateConfig(configuration{
+                profileName:    c.ProfileName(),
+                oAuthTokenData: data.String(),
+        }, nil, nil, nil)
 }
 
 func UpdateLogFilePath(c Configuration, filePath string) error {
-	return updateConfig(configuration{
-		profileName: c.ProfileName(),
-		logFilePath: filePath,
-	}, nil, nil, nil)
+        return updateConfig(configuration{
+                profileName: c.ProfileName(),
+                logFilePath: filePath,
+        }, nil, nil, nil)
+}
+
+func UpdateProxyConfiguration(c Configuration, proxyConf *ProxyConfiguration) error {
+        return updateConfig(configuration{
+                profileName:        c.ProfileName(),
+                proxyConfiguration: proxyConf,
+        }, nil, nil, nil)
 }
 
 func SetLoggingEnabled(c Configuration, loggingEnabled bool) error {
-	return updateConfig(configuration{
-		profileName: c.ProfileName(),
-	}, &loggingEnabled, nil, nil)
+        return updateConfig(configuration{
+                profileName: c.ProfileName(),
+        }, &loggingEnabled, nil, nil)
 }
 
 func SetExperimentalFeature(profileName string, featureName string, enabled bool) error {
-	viper.Set(fmt.Sprintf("%s.%s_enabled", profileName, featureName), enabled)
-	return viper.WriteConfig()
+        viper.Set(fmt.Sprintf("%s.%s_enabled", profileName, featureName), enabled)
+        return viper.WriteConfig()
 }
 
 func SetInputFormat(profileName string, format string) error {
-	viper.Set(fmt.Sprintf("%s.input_format", profileName), format)
-	return viper.WriteConfig()
+        viper.Set(fmt.Sprintf("%s.input_format", profileName), format)
+        return viper.WriteConfig()
 }
 
 func SetOutputFormat(profileName string, format string) error {
-	viper.Set(fmt.Sprintf("%s.output_format", profileName), format)
-	return viper.WriteConfig()
+        viper.Set(fmt.Sprintf("%s.output_format", profileName), format)
+        return viper.WriteConfig()
 }
 
 func GetInputFormat(profileName string) (string, error) {
-	err := viper.ReadInConfig()
-	if err != nil {
-		return "", err
-	}
-	return viper.GetString(fmt.Sprintf("%s.input_format", profileName)), nil
+        err := viper.ReadInConfig()
+        if err != nil {
+                return "", err
+        }
+        return viper.GetString(fmt.Sprintf("%s.input_format", profileName)), nil
 }
 
 func GetOutputFormat(profileName string) (string, error) {
-	err := viper.ReadInConfig()
-	if err != nil {
-		return "", err
-	}
-	return viper.GetString(fmt.Sprintf("%s.output_format", profileName)), nil
+        err := viper.ReadInConfig()
+        if err != nil {
+                return "", err
+        }
+        return viper.GetString(fmt.Sprintf("%s.output_format", profileName)), nil
 }
 
 func IsExperimentalFeatureEnabled(profileName string, featureName string) bool {
-	err := viper.ReadInConfig()
-	if err != nil {
-		return false
-	}
-	return viper.GetBool(fmt.Sprintf("%s.%s_enabled", profileName, featureName))
+        err := viper.ReadInConfig()
+        if err != nil {
+                return false
+        }
+        return viper.GetBool(fmt.Sprintf("%s.%s_enabled", profileName, featureName))
 }
 
 func SetAutoPaginationEnabled(c Configuration, autoPaginationEnabled bool) error {
-	return updateConfig(configuration{
-		profileName: c.ProfileName(),
-	}, nil, &autoPaginationEnabled, nil)
+        return updateConfig(configuration{
+                profileName: c.ProfileName(),
+        }, nil, &autoPaginationEnabled, nil)
 }
 
 func GetAutoPaginationEnabled(profileName string) (bool, error) {
-	err := viper.ReadInConfig()
-	if err != nil {
-		return false, err
-	}
-	return viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)), nil
+        err := viper.ReadInConfig()
+        if err != nil {
+                return false, err
+        }
+        return viper.GetBool(fmt.Sprintf("%s.auto_pagination_enabled", profileName)), nil
 }
 
 func OverridesApplied() bool {
-	return ClientId != "" || ClientSecret != "" || Environment != "" || AccessToken != "" ||
-		os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != "" || os.Getenv("GENESYSCLOUD_ACCESS_TOKEN") != ""
+        return ClientId != "" || ClientSecret != "" || Environment != "" || AccessToken != "" ||
+                os.Getenv("GENESYSCLOUD_OAUTHCLIENT_ID") != "" || os.Getenv("GENESYSCLOUD_OAUTHCLIENT_SECRET") != "" || os.Getenv("GENESYSCLOUD_REGION") != "" || os.Getenv("GENESYSCLOUD_ACCESS_TOKEN") != ""
 }
 
 func updateConfig(c configuration, loggingEnabled *bool, autoPaginationEnabled *bool, secureLoginEnabled *bool) error {
-	if c.clientID != "" {
-		viper.Set(fmt.Sprintf("%s.client_credentials", c.profileName), c.clientID)
-	}
-	if c.clientSecret != "" {
-		viper.Set(fmt.Sprintf("%s.client_secret", c.profileName), c.clientSecret)
-	}
-	if c.redirectURI != "" {
-		viper.Set(fmt.Sprintf("%s.redirect_uri", c.profileName), c.redirectURI)
-	}
-	if c.environment != "" {
-		viper.Set(fmt.Sprintf("%s.environment", c.profileName), c.environment)
-	}
-	if c.oAuthTokenData != "" {
-		viper.Set(fmt.Sprintf("%s.oauth_token_data", c.profileName), c.oAuthTokenData)
-	}
-	if c.accessToken != "" {
-		viper.Set(fmt.Sprintf("%s.access_token", c.profileName), c.accessToken)
-	}
-	if c.logFilePath != "" {
-		viper.Set(fmt.Sprintf("%s.log_file_path", c.profileName), c.logFilePath)
-	}
-	if loggingEnabled != nil {
-		viper.Set(fmt.Sprintf("%s.logging_enabled", c.profileName), *loggingEnabled)
-	}
-	if autoPaginationEnabled != nil {
-		viper.Set(fmt.Sprintf("%s.auto_pagination_enabled", c.profileName), *autoPaginationEnabled)
-	}
-	if secureLoginEnabled != nil {
-		viper.Set(fmt.Sprintf("%s.secure_login_enabled", c.profileName), *secureLoginEnabled)
-	}
+        if c.clientID != "" {
+                viper.Set(fmt.Sprintf("%s.client_credentials", c.profileName), c.clientID)
+        }
+        if c.clientSecret != "" {
+                viper.Set(fmt.Sprintf("%s.client_secret", c.profileName), c.clientSecret)
+        }
+        if c.redirectURI != "" {
+                viper.Set(fmt.Sprintf("%s.redirect_uri", c.profileName), c.redirectURI)
+        }
+        if c.environment != "" {
+                viper.Set(fmt.Sprintf("%s.environment", c.profileName), c.environment)
+        }
+        if c.oAuthTokenData != "" {
+                viper.Set(fmt.Sprintf("%s.oauth_token_data", c.profileName), c.oAuthTokenData)
+        }
+        if c.accessToken != "" {
+                viper.Set(fmt.Sprintf("%s.access_token", c.profileName), c.accessToken)
+        }
+        if c.logFilePath != "" {
+                viper.Set(fmt.Sprintf("%s.log_file_path", c.profileName), c.logFilePath)
+        }
+        if loggingEnabled != nil {
+                viper.Set(fmt.Sprintf("%s.logging_enabled", c.profileName), *loggingEnabled)
+        }
+        if autoPaginationEnabled != nil {
+                viper.Set(fmt.Sprintf("%s.auto_pagination_enabled", c.profileName), *autoPaginationEnabled)
+        }
+        if secureLoginEnabled != nil {
+                viper.Set(fmt.Sprintf("%s.secure_login_enabled", c.profileName), *secureLoginEnabled)
+        }
 
-	if viper.ConfigFileUsed() == "" {
-		return nil
-	}
+        if c.proxyConfiguration != nil {
+                viper.Set(fmt.Sprintf("%s.proxy", c.profileName), *c.proxyConfiguration)
+        } else {
+			viper.Set(fmt.Sprintf("%s.proxy", c.profileName), new(ProxyConfiguration))
+		}
 
-	return viper.WriteConfig()
+        if viper.ConfigFileUsed() == "" {
+                return nil
+        }
+
+        return viper.WriteConfig()
 }
 
 func writeConfig(c Configuration, data *models.OAuthTokenData, logFilePath string, loggingEnabled *bool, autoPaginationEnabled *bool) error {
-	viper.Set(fmt.Sprintf("%s.client_credentials", c.ProfileName()), c.ClientID())
-	viper.Set(fmt.Sprintf("%s.client_secret", c.ProfileName()), c.ClientSecret())
-	viper.Set(fmt.Sprintf("%s.redirect_uri", c.ProfileName()), c.RedirectURI())
-	viper.Set(fmt.Sprintf("%s.environment", c.ProfileName()), c.Environment())
-	viper.Set(fmt.Sprintf("%s.access_token", c.ProfileName()), c.AccessToken())
-	viper.Set(fmt.Sprintf("%s.secure_login_enabled", c.ProfileName()), c.SecureLoginEnabled())
-	if data != nil {
-		viper.Set(fmt.Sprintf("%s.oauth_token_data", c.ProfileName()), data.String())
-	}
-	if logFilePath != "" {
-		viper.Set(fmt.Sprintf("%s.log_file_path", c.ProfileName()), logFilePath)
-	}
-	if loggingEnabled != nil {
-		viper.Set(fmt.Sprintf("%s.logging_enabled", c.ProfileName()), *loggingEnabled)
-	}
-	if autoPaginationEnabled != nil {
-		viper.Set(fmt.Sprintf("%s.auto_pagination_enabled", c.ProfileName()), *autoPaginationEnabled)
-	}
+        viper.Set(fmt.Sprintf("%s.client_credentials", c.ProfileName()), c.ClientID())
+        viper.Set(fmt.Sprintf("%s.client_secret", c.ProfileName()), c.ClientSecret())
+        viper.Set(fmt.Sprintf("%s.redirect_uri", c.ProfileName()), c.RedirectURI())
+        viper.Set(fmt.Sprintf("%s.environment", c.ProfileName()), c.Environment())
+        viper.Set(fmt.Sprintf("%s.access_token", c.ProfileName()), c.AccessToken())
+        viper.Set(fmt.Sprintf("%s.secure_login_enabled", c.ProfileName()), c.SecureLoginEnabled())
+        if data != nil {
+                viper.Set(fmt.Sprintf("%s.oauth_token_data", c.ProfileName()), data.String())
+        }
+        if logFilePath != "" {
+                viper.Set(fmt.Sprintf("%s.log_file_path", c.ProfileName()), logFilePath)
+        }
+        if loggingEnabled != nil {
+                viper.Set(fmt.Sprintf("%s.logging_enabled", c.ProfileName()), *loggingEnabled)
+        }
+        if autoPaginationEnabled != nil {
+                viper.Set(fmt.Sprintf("%s.auto_pagination_enabled", c.ProfileName()), *autoPaginationEnabled)
+        }
+        if c.ProxyConfiguration() != nil {
+                viper.Set(fmt.Sprintf("%s.proxy", c.ProfileName()), *c.ProxyConfiguration())
+        }
 
-	//Checking to see if the file does not exist.  It it doesnt we write out the config as default config.toml
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			homeDir, _ := os.UserHomeDir()
-			gcDir := fmt.Sprintf("%s/.gc", homeDir)
-			if _, err := os.Stat(gcDir); os.IsNotExist(err) {
-				err = os.Mkdir(gcDir, 0755)
-				if err != nil {
-					return err
-				}
-			}
-			return viper.WriteConfigAs(fmt.Sprintf("%s/config.toml", gcDir))
-		}
-	}
+        //Checking to see if the file does not exist.  It it doesnt we write out the config as default config.toml
+        if err := viper.ReadInConfig(); err != nil {
+                if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+                        homeDir, _ := os.UserHomeDir()
+                        gcDir := fmt.Sprintf("%s/.gc", homeDir)
+                        if _, err := os.Stat(gcDir); os.IsNotExist(err) {
+                                err = os.Mkdir(gcDir, 0755)
+                                if err != nil {
+                                        return err
+                                }
+                        }
+                        return viper.WriteConfigAs(fmt.Sprintf("%s/config.toml", gcDir))
+                }
+        }
 
-	return viper.WriteConfig()
+        return viper.WriteConfig()
 }

--- a/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
+++ b/resources/sdk/clisdkclient/extensions/mocks/mockclientconfig.go
@@ -19,6 +19,7 @@ type MockClientConfig struct {
 	LoggingEnabledFunc        func() bool
 	AutoPaginationEnabledFunc func() bool
 	SecureLoginEnabledFunc    func() bool
+	ProxyConfigurationFunc    func() *config.ProxyConfiguration
 }
 
 var UpdatedAccessToken string
@@ -65,6 +66,10 @@ func (m *MockClientConfig) SecureLoginEnabled() bool {
 
 func (m *MockClientConfig) AutoPaginationEnabled() bool {
 	return m.AutoPaginationEnabledFunc()
+}
+
+func (m *MockClientConfig) ProxyConfiguration() *config.ProxyConfiguration {
+	return m.ProxyConfigurationFunc()
 }
 
 func (m *MockClientConfig) String() string {

--- a/resources/sdk/clisdkclient/extensions/restclient/restclient_test.go
+++ b/resources/sdk/clisdkclient/extensions/restclient/restclient_test.go
@@ -112,11 +112,13 @@ func TestAuthorizeWithImplicitLogin(t *testing.T) {
 
 func TestLowLevelRestClient(t *testing.T) {
 	tests := buildTestCaseTable()
-
+	mockConfig := buildMockConfig("DEFAULT", "mypurecloud.com", "", false, utils.GenerateGuid(), utils.GenerateGuid(), "")
+	
 	for _, tc := range tests {
 		restClient := &RESTClient{
 			environment: tc.targetEnv,
 			token:       tc.oAuthToken,
+			configuration: mockConfig,
 		}
 
 		setRestClientDoMock(t, tc)
@@ -141,11 +143,13 @@ func TestLowLevelRestClient(t *testing.T) {
 
 func TestHighLevelRestClient(t *testing.T) {
 	tests := buildTestCaseTable()
-
+	mockConfig := buildMockConfig("DEFAULT", "mypurecloud.com", "", false, utils.GenerateGuid(), utils.GenerateGuid(), "")
+	
 	for _, tc := range tests {
 		restClient := &RESTClient{
 			environment: tc.targetEnv,
 			token:       tc.oAuthToken,
+			configuration: mockConfig,
 		}
 
 		setRestClientDoMock(t, tc)
@@ -223,6 +227,10 @@ func buildMockConfig(profileName string, environment string, redirectURI string,
 		return oauthTokenData
 	}
 
+	mockConfig.ProxyConfigurationFunc = func() *config.ProxyConfiguration {
+		return &config.ProxyConfiguration{}
+	}
+	
 	return mockConfig
 }
 

--- a/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
+++ b/resources/sdk/clisdkclient/extensions/services/commandservice_test.go
@@ -29,8 +29,8 @@ type apiClientTest struct {
 }
 
 func TestRetryWithData(t *testing.T) {
-	restclientNewRESTClient = mockNewRESTClient
 	configGetConfig = mockGetConfig
+	restclientNewRESTClient = mockNewRESTClient
 	restclient.UpdateOAuthToken = mocks.UpdateOAuthToken
 
 	c := commandService{
@@ -258,7 +258,9 @@ func setRestClientDoMockForReAuthenticate(tc apiClientTest) {
 
 //mockNewRESTClient returns a mock RESTClient object for the commandservice tests and sets the object in the restclient package
 func mockNewRESTClient(_ config.Configuration) *restclient.RESTClient {
+	c,_ := mockGetConfig("")
 	restclient.RestClient = &restclient.RESTClient{}
+	restclient.RestClient.SetConfig(c)
 	return restclient.RestClient
 }
 
@@ -304,6 +306,10 @@ func mockGetConfig(profileName string) (config.Configuration, error) {
 
 	mockConfig.AccessTokenFunc = func() string {
 		return ""
+	}
+
+	mockConfig.ProxyConfigurationFunc = func() *config.ProxyConfiguration {
+		return &config.ProxyConfiguration{}
 	}
 
 	return mockConfig, nil

--- a/resources/sdk/clisdkclient/resources/operationNameOverrides.json
+++ b/resources/sdk/clisdkclient/resources/operationNameOverrides.json
@@ -375,5 +375,18 @@
 		"patch": {
 			"name": "update"
 		}
-	}
+	},
+	"/api/v2/voicemail/userpolicies/{userId}": {
+		"put": {
+			"name": "put"
+		},
+		"patch": {
+			"name": "update"
+		}
+	},
+	"/api/v2/chats/settings": {
+        "put": {
+            "name": "updateSettings"
+        }
+    }
 }

--- a/resources/sdk/clisdkclient/resources/operationNameOverrides.json
+++ b/resources/sdk/clisdkclient/resources/operationNameOverrides.json
@@ -375,18 +375,5 @@
 		"patch": {
 			"name": "update"
 		}
-	},
-	"/api/v2/voicemail/userpolicies/{userId}": {
-		"put": {
-			"name": "put"
-		},
-		"patch": {
-			"name": "update"
-		}
-	},
-	"/api/v2/chats/settings": {
-        "put": {
-            "name": "updateSettings"
-        }
-    }
+	}
 }

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -164,18 +164,16 @@ Host - Host Ip or DNS of the proxy server
 Protocol - Protocol required to connect to the Proxy (http or https)
 
 The 'ProxyConfiguration' has another section which is an optional section. If the proxy requires authentication to connect to
-'Auth' needs to be mentioned under the 'ProxyConfiguration'. This section can be removed from the JSON file if no authentication is required.
+'userName' and 'password' needs to be mentioned under the 'ProxyConfiguration'. This section can be removed from the JSON file if no authentication is required.
 
 JSON configuration file:
+
 {
-    "proxy": {
         "host": "hostname",
         "protocol": "http",
-        "port": "8888"
-        "auth": {
-            "username": "username",
-            "password": "password"
-        }
+        "port": "8888",
+        "userName": "username",
+        "password": "password"
 }
 
 Command to Enable Proxy:

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -153,6 +153,37 @@ gc autopagination status
 ```
 In addition, there is a new `--stream` or `-s` flag for paginatable resources. This will paginate through the results and print them one page at a time leaving the page information intact.
 
+# Proxy Configuration
+
+To add a proxy configuration for the CLI , you can pass file parameter with proxy configuration
+in it.
+
+The `ProxyConfiguration` object has 3 properties that determine the URL for proxying.
+Port - Port of the Proxy server
+Host - Host Ip or DNS of the proxy server
+Protocol - Protocol required to connect to the Proxy (http or https)
+
+The 'ProxyConfiguration' has another section which is an optional section. If the proxy requires authentication to connect to
+'Auth' needs to be mentioned under the 'ProxyConfiguration'. This section can be removed from the JSON file if no authentication is required.
+
+JSON configuration file:
+{
+    "proxy": {
+        "host": "hostname",
+        "protocol": "http",
+        "port": "8888"
+        "auth": {
+            "username": "username",
+            "password": "password"
+        }
+}
+
+Command to Enable Proxy:
+gc proxy --file=proxy.json
+
+To disable this Proxy Configuration, run the following command.
+gc proxy disable
+
 # Autocompletion
 
 See below for instructions on how to enable autocompletion for supported shells:

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -1,435 +1,433 @@
 package restclient
 
 import (
-	"errors"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/logger"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/retry"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/utils"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/restclient/tls"
-	"log"
-	"net/http"
+        "errors"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/logger"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/models"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/restclient/tls"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/retry"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/utils"
+        "log"
+        "net/http"
 
-	"os/exec"
-	"os"
-	"runtime"
-	"strconv"
-	"time"
+        "os"
+        "os/exec"
+        "runtime"
+        "strconv"
+        "time"
 
-	"bytes"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
-	"io/ioutil"
-	"net/url"
-	"strings"
+        "bytes"
+        "encoding/base64"
+        "encoding/json"
+        "fmt"
+        "github.com/mypurecloud/platform-client-sdk-cli/build/gc/config"
+        "io/ioutil"
+        "net/url"
+        "strings"
 
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/tidwall/pretty"
+        "github.com/hashicorp/go-retryablehttp"
+        "github.com/tidwall/pretty"
 )
 
 var (
-	Client              retryablehttp.Client
-	ClientDo            = Client.Do
-	RestClient          *RESTClient
-	UpdateOAuthToken    = config.UpdateOAuthToken
-	OverridesApplied    = config.OverridesApplied
-	openBrowserForLogin = openBrowserForLoginFunc
-	startLocalServer    = startLocalServerFunc
+        Client              retryablehttp.Client
+        ClientDo            = Client.Do
+        RestClient          *RESTClient
+        UpdateOAuthToken    = config.UpdateOAuthToken
+        OverridesApplied    = config.OverridesApplied
+        openBrowserForLogin = openBrowserForLoginFunc
+        startLocalServer    = startLocalServerFunc
 )
 
 type RESTClient struct {
-	environment string
-	token       string
-	configuration config.Configuration
+        environment   string
+        token         string
+        configuration config.Configuration
 }
 
 func (r *RESTClient) SetEnv(env string) {
-	r.environment = env
+        r.environment = env
 }
 
 func (r *RESTClient) SetConfig(c config.Configuration) {
-	r.configuration = c
+        r.configuration = c
 }
 
-//Get executes an HTTP Get
+// Get executes an HTTP Get
 func (r *RESTClient) Get(uri string) (string, error) {
-	return r.callAPI(http.MethodGet, uri, "")
+        return r.callAPI(http.MethodGet, uri, "")
 }
 
-//Head executes an HTTP Head
+// Head executes an HTTP Head
 func (r *RESTClient) Head(uri string) (string, error) {
-	return r.callAPI(http.MethodHead, uri, "")
+        return r.callAPI(http.MethodHead, uri, "")
 }
 
-//Put executes an HTTP Put
+// Put executes an HTTP Put
 func (r *RESTClient) Put(uri string, data string) (string, error) {
-	return r.callAPI(http.MethodPut, uri, data)
+        return r.callAPI(http.MethodPut, uri, data)
 }
 
-//Post executes an HTTP Post
+// Post executes an HTTP Post
 func (r *RESTClient) Post(uri string, data string) (string, error) {
-	return r.callAPI(http.MethodPost, uri, data)
+        return r.callAPI(http.MethodPost, uri, data)
 }
 
-//Patch executes an HTTP Patch
+// Patch executes an HTTP Patch
 func (r *RESTClient) Patch(uri string, data string) (string, error) {
-	return r.callAPI(http.MethodPatch, uri, data)
+        return r.callAPI(http.MethodPatch, uri, data)
 }
 
-//Delete executes an HTTP Delete
+// Delete executes an HTTP Delete
 func (r *RESTClient) Delete(uri string) (string, error) {
-	return r.callAPI(http.MethodDelete, uri, "")
+        return r.callAPI(http.MethodDelete, uri, "")
 }
 
 func (r *RESTClient) callAPI(method string, uri string, data string) (string, error) {
-	var apiURI *url.URL
-	if !strings.HasPrefix(uri, "/") {
-		uri = fmt.Sprintf("/%v", uri)
-	}
-	if !strings.Contains(r.environment, "localhost") {
-		apiURI, _ = url.Parse(fmt.Sprintf("https://api.%s%s", r.environment, uri))
-	} else {
-		apiURI, _ = url.Parse(fmt.Sprintf("http://%s%s", r.environment, uri))
-	}
+        var apiURI *url.URL
+        if !strings.HasPrefix(uri, "/") {
+                uri = fmt.Sprintf("/%v", uri)
+        }
+        if !strings.Contains(r.environment, "localhost") {
+                apiURI, _ = url.Parse(fmt.Sprintf("https://api.%s%s", r.environment, uri))
+        } else {
+                apiURI, _ = url.Parse(fmt.Sprintf("http://%s%s", r.environment, uri))
+        }
 
-	logger.Infof("Calling API with method: %v, URI: %v, data: %v", method, uri, data)
+        logger.Infof("Calling API with method: %v, URI: %v, data: %v", method, uri, data)
 
-	request := &retryablehttp.Request{
-		Request: &http.Request{
-			URL:    apiURI,
-			Close:  true,
-			Method: strings.ToUpper(method),
-			Header: make(map[string][]string),
-		},
-	}
+        request := &retryablehttp.Request{
+                Request: &http.Request{
+                        URL:    apiURI,
+                        Close:  true,
+                        Method: strings.ToUpper(method),
+                        Header: make(map[string][]string),
+                },
+        }
 
-	//Setting up the auth header
-	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Cache-Control", "no-cache")
+        //Setting up the auth header
+        request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.token))
+        request.Header.Set("Content-Type", "application/json")
+        request.Header.Set("Cache-Control", "no-cache")
 
-	//User-Agent and SDK version headers
-	request.Header.Set("User-Agent", "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen{{/httpUserAgent}}/go-cli")
-	request.Header.Set("purecloud-sdk", "{{packageVersion}}")
+        //User-Agent and SDK version headers
+        request.Header.Set("User-Agent", "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen{{/httpUserAgent}}/go-cli")
+        request.Header.Set("purecloud-sdk", "{{packageVersion}}")
 
-	if data != "" {
-		request.Body = ioutil.NopCloser(bytes.NewBuffer([]byte(data)))
-	}
+        if data != "" {
+                request.Body = ioutil.NopCloser(bytes.NewBuffer([]byte(data)))
+        }
 
-	retryConfiguration := retry.GetRetryConfiguration()
-	if retryConfiguration == nil {
-		Client.RetryMax = 0
-		Client.RetryWaitMax = 0
-	} else {
-		Client.RetryWaitMax = retryConfiguration.RetryWaitMax
-		Client.RetryWaitMin = retryConfiguration.RetryWaitMin
-		Client.RetryMax = retryConfiguration.RetryMax
-		if retryConfiguration.RequestLogHook == nil {
-			Client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retryNumber int) {
-				if retryNumber > 1 {
-					logger.Warnf("%v %v request failed. Retry count: %v\n", req.Method, req.URL, retryNumber)
-				}
-			}
-		} else {
-			Client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retryNumber int) {
-				retryConfiguration.RequestLogHook(req, retryNumber)
-			}
-		}
-	}
-    
-    if r.configuration != nil {
-		proxyConfiguration := r.configuration.ProxyConfiguration()
-	if proxyConfiguration != nil && proxyConfiguration.Protocol != "" {
-		var proxyUrl *url.URL
+        retryConfiguration := retry.GetRetryConfiguration()
+        if retryConfiguration == nil {
+                Client.RetryMax = 0
+                Client.RetryWaitMax = 0
+        } else {
+                Client.RetryWaitMax = retryConfiguration.RetryWaitMax
+                Client.RetryWaitMin = retryConfiguration.RetryWaitMin
+                Client.RetryMax = retryConfiguration.RetryMax
+                if retryConfiguration.RequestLogHook == nil {
+                        Client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retryNumber int) {
+                                if retryNumber > 1 {
+                                        logger.Warnf("%v %v request failed. Retry count: %v\n", req.Method, req.URL, retryNumber)
+                                }
+                        }
+                } else {
+                        Client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retryNumber int) {
+                                retryConfiguration.RequestLogHook(req, retryNumber)
+                        }
+                }
+        }
 
-		if proxyConfiguration.Auth != nil && proxyConfiguration.Auth.UserName != "" && proxyConfiguration.Auth.Password != "" {
-			proxyUrl = &url.URL {
-      		Scheme: proxyConfiguration.Protocol,
-     	    User:   url.UserPassword(proxyConfiguration.Auth.UserName, 
-	  							proxyConfiguration.Auth.Password),
-      		Host:   proxyConfiguration.Host + ":" + proxyConfiguration.Port,
-    		}
-		} else {
-				urlString := proxyConfiguration.Protocol + "://" +
-						proxyConfiguration.Host  + ":" +
-						proxyConfiguration.Port
-				proxyUrl, _ = url.Parse(urlString)
-		}
+        if r.configuration != nil {
+                proxyConfiguration := r.configuration.ProxyConfiguration()
+                if proxyConfiguration != nil && proxyConfiguration.Protocol != "" {
+                        var proxyUrl *url.URL
+                        if proxyConfiguration.UserName != "" && proxyConfiguration.Password != "" {
+                                proxyUrl = &url.URL{
+                                        Scheme: proxyConfiguration.Protocol,
+                                        User: url.UserPassword(proxyConfiguration.UserName,
+                                                proxyConfiguration.Password),
+                                        Host: proxyConfiguration.Host + ":" + proxyConfiguration.Port,
+                                }
+                        } else {
+                                urlString := proxyConfiguration.Protocol + "://" +
+                                        proxyConfiguration.Host + ":" +
+                                        proxyConfiguration.Port
+                                proxyUrl, _ = url.Parse(urlString)
+                        }
 
-				tr := &http.Transport {
-        			Proxy:  http.ProxyURL(proxyUrl),
-    			}
+                        tr := &http.Transport{
+                                Proxy: http.ProxyURL(proxyUrl),
+                        }
 
-				Client.HTTPClient.Transport = tr
-	}
-	}
-	
-	//Executing the request
-	resp, err := ClientDo(request)
-	if err != nil {
-		return "", err
-	}
-	timestampMS := time.Now().UnixNano() / int64(time.Millisecond)
-	defer resp.Body.Close()
+                        Client.HTTPClient.Transport = tr
+                }
+        }
 
-	correlationId := resp.Header["Inin-Correlation-Id"]
-	if correlationId != nil {
-		logger.Infof("API response Correlation ID: %v, method: %v, URI: %v, timestamp(ms): %d", correlationId[0], method, uri, timestampMS)
-	}
+        //Executing the request
+        resp, err := ClientDo(request)
+        if err != nil {
+                return "", err
+        }
+        timestampMS := time.Now().UnixNano() / int64(time.Millisecond)
+        defer resp.Body.Close()
 
-	response, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
+        correlationId := resp.Header["Inin-Correlation-Id"]
+        if correlationId != nil {
+                logger.Infof("API response Correlation ID: %v, method: %v, URI: %v, timestamp(ms): %d", correlationId[0], method, uri, timestampMS)
+        }
 
-	responseData := string(response)
+        response, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+                return "", err
+        }
 
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		httpError := models.HttpStatusError{Verb: method, Path: uri, StatusCode: resp.StatusCode, Headers: resp.Header, Body: fmt.Sprintf("%s", pretty.Pretty([]byte(responseData)))}
-		logger.Warn("Error from API:", httpError.ErrorDescriptive())
-		return "", httpError
-	}
+        responseData := string(response)
 
-	return responseData, nil
+        if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+                httpError := models.HttpStatusError{Verb: method, Path: uri, StatusCode: resp.StatusCode, Headers: resp.Header, Body: fmt.Sprintf("%s", pretty.Pretty([]byte(responseData)))}
+                logger.Warn("Error from API:", httpError.ErrorDescriptive())
+                return "", httpError
+        }
+
+        return responseData, nil
 }
 
-//Authorize authenticates the user using the client credentials in their profile.
+// Authorize authenticates the user using the client credentials in their profile.
 func Authorize(c config.Configuration) (models.OAuthTokenData, error) {
-	if strings.Contains(c.Environment(), "localhost") {
-		return models.OAuthTokenData{}, nil
-	}
+        if strings.Contains(c.Environment(), "localhost") {
+                return models.OAuthTokenData{}, nil
+        }
 
-	oAuthTokenData := &models.OAuthTokenData{}
-	if !OverridesApplied() && c.OAuthTokenData() != "" {
-		err := json.Unmarshal([]byte(c.OAuthTokenData()), oAuthTokenData)
-		if err != nil {
-			return models.OAuthTokenData{}, err
-		}
-		oauthTokenExpiry, _ := time.Parse(time.RFC3339, oAuthTokenData.OAuthTokenExpiry)
-		if oauthTokenExpiry.After(time.Now()) {
-			return *oAuthTokenData, nil
-		}
-		logger.Info("Authorizing because token has expired")
-	}
+        oAuthTokenData := &models.OAuthTokenData{}
+        if !OverridesApplied() && c.OAuthTokenData() != "" {
+                err := json.Unmarshal([]byte(c.OAuthTokenData()), oAuthTokenData)
+                if err != nil {
+                        return models.OAuthTokenData{}, err
+                }
+                oauthTokenExpiry, _ := time.Parse(time.RFC3339, oAuthTokenData.OAuthTokenExpiry)
+                if oauthTokenExpiry.After(time.Now()) {
+                        return *oAuthTokenData, nil
+                }
+                logger.Info("Authorizing because token has expired")
+        }
 
-	return authorize(c)
+        return authorize(c)
 }
 
-//ReAuthenticate re-authenticates the user using the client credentials in their profile.
+// ReAuthenticate re-authenticates the user using the client credentials in their profile.
 func ReAuthenticate(c config.Configuration) (models.OAuthTokenData, error) {
-	oAuthToken, err := authorize(c)
-	if err == nil {
-		RestClient.token = oAuthToken.AccessToken
-	}
+        oAuthToken, err := authorize(c)
+        if err == nil {
+                RestClient.token = oAuthToken.AccessToken
+        }
 
-	return oAuthToken, err
+        return oAuthToken, err
 }
 
 func authorize(c config.Configuration) (models.OAuthTokenData, error) {
-	authChannel := make(chan models.OAuthToken)
+        authChannel := make(chan models.OAuthToken)
+        // Using implicit grant
+        if c.RedirectURI() != "" {
+                if c.SecureLoginEnabled() {
+                        // Generate a self-signed X.509 certificate for a TLS server
+                        err := tls.GenerateCerts()
+                        if err != nil {
+                                oAuthTokenResponse := &models.OAuthTokenData{}
+                                return *oAuthTokenResponse, err
+                        }
+                }
+                go startLocalServer(c, authChannel)
+                openBrowserForLogin(c.RedirectURI())
 
-	// Using implicit grant
-	if c.RedirectURI() != "" {
-		if c.SecureLoginEnabled() {
-			// Generate a self-signed X.509 certificate for a TLS server
-			err := tls.GenerateCerts()
-			if err != nil {
-				oAuthTokenResponse := &models.OAuthTokenData{}
-				return *oAuthTokenResponse, err
-			}
-		}
-		go startLocalServer(c, authChannel)
-		openBrowserForLogin(c.RedirectURI())
+                oAuthToken := <-authChannel
+                if oAuthToken.Error != "" {
+                        oAuthTokenResponse := &models.OAuthTokenData{}
+                        return *oAuthTokenResponse, errors.New(oAuthToken.Error)
+                }
 
-		oAuthToken := <-authChannel
-		if oAuthToken.Error != "" {
-			oAuthTokenResponse := &models.OAuthTokenData{}
-			return *oAuthTokenResponse, errors.New(oAuthToken.Error)
-		}
+                return createOAuthTokenResponse(c, oAuthToken)
+        }
 
-		return createOAuthTokenResponse(c, oAuthToken)
-	}
+        loginURI, _ := url.Parse(fmt.Sprintf("https://login.%s/oauth/token", c.Environment()))
 
-	loginURI, _ := url.Parse(fmt.Sprintf("https://login.%s/oauth/token", c.Environment()))
+        request := &retryablehttp.Request{
+                Request: &http.Request{
+                        URL:    loginURI,
+                        Close:  true,
+                        Method: http.MethodPost,
+                        Header: make(map[string][]string),
+                },
+        }
 
-	request := &retryablehttp.Request{
-		Request: &http.Request{
-			URL:    loginURI,
-			Close:  true,
-			Method: http.MethodPost,
-			Header: make(map[string][]string),
-		},
-	}
+        //Setting up the basic auth headers for the call
+        authHeaderString := fmt.Sprintf("%s:%s", c.ClientID(), c.ClientSecret())
+        authHeader := base64.StdEncoding.EncodeToString([]byte(authHeaderString))
+        request.Header.Set("Authorization", fmt.Sprintf("Basic %s", authHeader))
+        request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	//Setting up the basic auth headers for the call
-	authHeaderString := fmt.Sprintf("%s:%s", c.ClientID(), c.ClientSecret())
-	authHeader := base64.StdEncoding.EncodeToString([]byte(authHeaderString))
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", authHeader))
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+        //User-Agent and SDK version headers
+        request.Header.Set("User-Agent", "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen{{/httpUserAgent}}/go-cli")
+        request.Header.Set("purecloud-sdk", "{{packageVersion}}")
 
-	//User-Agent and SDK version headers
-	request.Header.Set("User-Agent", "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen{{/httpUserAgent}}/go-cli")
-	request.Header.Set("purecloud-sdk", "{{packageVersion}}")
+        //Setting up the form data
+        form := url.Values{}
+        form["grant_type"] = []string{"client_credentials"}
+        request.Body = ioutil.NopCloser(strings.NewReader(form.Encode()))
 
-	//Setting up the form data
-	form := url.Values{}
-	form["grant_type"] = []string{"client_credentials"}
-	request.Body = ioutil.NopCloser(strings.NewReader(form.Encode()))
+        //Executing the request
+        resp, err := ClientDo(request)
+        if err != nil {
+                logger.Fatal(err)
+        }
 
-	//Executing the request
-	resp, err := ClientDo(request)
-	if err != nil {
-		logger.Fatal(err)
-	}
+        defer resp.Body.Close()
 
-	defer resp.Body.Close()
+        oAuthTokenResponse := &models.OAuthTokenData{}
+        // Read Response Body
+        responseData, err := ioutil.ReadAll(resp.Body)
+        if err != nil {
+                return *oAuthTokenResponse, err
+        }
 
-	oAuthTokenResponse := &models.OAuthTokenData{}
-	// Read Response Body
-	responseData, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return *oAuthTokenResponse, err
-	}
+        if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+                httpError := models.HttpStatusError{Verb: http.MethodPost, Path: loginURI.Path, StatusCode: resp.StatusCode, Headers: resp.Header, Body: fmt.Sprintf("%s", pretty.Pretty(responseData))}
+                return *oAuthTokenResponse, httpError
+        }
 
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		httpError := models.HttpStatusError{Verb: http.MethodPost, Path: loginURI.Path, StatusCode: resp.StatusCode, Headers: resp.Header, Body: fmt.Sprintf("%s", pretty.Pretty(responseData))}
-		return *oAuthTokenResponse, httpError
-	}
-
-	oAuthToken := &models.OAuthToken{}
-	err = json.Unmarshal(responseData, &oAuthToken)
-	if err != nil {
-		return *oAuthTokenResponse, err
-	}
-	return createOAuthTokenResponse(c, *oAuthToken)
+        oAuthToken := &models.OAuthToken{}
+        err = json.Unmarshal(responseData, &oAuthToken)
+        if err != nil {
+                return *oAuthTokenResponse, err
+        }
+        return createOAuthTokenResponse(c, *oAuthToken)
 }
 
-func createOAuthTokenResponse(c config.Configuration, oAuthToken models.OAuthToken) (models.OAuthTokenData, error)  {
-	oAuthTokenResponse := &models.OAuthTokenData{}
-	oAuthTokenExpiry := time.Now().Add(utils.SecondsToNanoSeconds(oAuthToken.ExpiresIn))
+func createOAuthTokenResponse(c config.Configuration, oAuthToken models.OAuthToken) (models.OAuthTokenData, error) {
+        oAuthTokenResponse := &models.OAuthTokenData{}
+        oAuthTokenExpiry := time.Now().Add(utils.SecondsToNanoSeconds(oAuthToken.ExpiresIn))
 
-	oAuthTokenResponse = &models.OAuthTokenData{
-		OAuthToken:       oAuthToken,
-		OAuthTokenExpiry: oAuthTokenExpiry.Format(time.RFC3339),
-	}
+        oAuthTokenResponse = &models.OAuthTokenData{
+                OAuthToken:       oAuthToken,
+                OAuthTokenExpiry: oAuthTokenExpiry.Format(time.RFC3339),
+        }
 
-	if !OverridesApplied() {
-		err := UpdateOAuthToken(c, oAuthTokenResponse)
-		if err != nil {
-			return *oAuthTokenResponse, err
-		}
-	}
+        if !OverridesApplied() {
+                err := UpdateOAuthToken(c, oAuthTokenResponse)
+                if err != nil {
+                        return *oAuthTokenResponse, err
+                }
+        }
 
-	return *oAuthTokenResponse, nil
+        return *oAuthTokenResponse, nil
 }
 
 // Starts the local server at the redirect URI
 func startLocalServerFunc(c config.Configuration, authChannel chan models.OAuthToken) {
-	u, err := url.Parse(c.RedirectURI())
-	if err != nil {
-		logger.Fatalf("Error parsing redirect URL: %v", err)
-	}
-	path := u.Path
-	if path == "" {
-		path = "/"
-	}
+        u, err := url.Parse(c.RedirectURI())
+        if err != nil {
+                logger.Fatalf("Error parsing redirect URL: %v", err)
+        }
+        path := u.Path
+        if path == "" {
+                path = "/"
+        }
 
-	var oAuthToken models.OAuthToken
-	implicitWebpage := models.ImplicitWebpage{}
-	// Set initial web page as one containing the javascript to perform implicit login
-	initialPage := implicitWebpage.GetImplicitWebpage(c.ClientID(), c.Environment(), c.RedirectURI())
-	activePage := initialPage
+        var oAuthToken models.OAuthToken
+        implicitWebpage := models.ImplicitWebpage{}
+        // Set initial web page as one containing the javascript to perform implicit login
+        initialPage := implicitWebpage.GetImplicitWebpage(c.ClientID(), c.Environment(), c.RedirectURI())
+        activePage := initialPage
 
-	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprintf(w, activePage)
-		if err != nil {
-			logger.Fatalf("Error handling request: %v", err)
-		}
+        http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+                _, err := fmt.Fprintf(w, activePage)
+                if err != nil {
+                        logger.Fatalf("Error handling request: %v", err)
+                }
 
-		// If no longer displaying initial page -
-		// Give time for initialPage to refresh on the browser thereby printing the response page,
-		// Then close channel & server
-		if activePage != initialPage {
-			time.Sleep(4 * time.Second)
-			authChannel <- oAuthToken
-			close(authChannel)
-			return
-		}
+                // If no longer displaying initial page -
+                // Give time for initialPage to refresh on the browser thereby printing the response page,
+                // Then close channel & server
+                if activePage != initialPage {
+                        time.Sleep(4 * time.Second)
+                        authChannel <- oAuthToken
+                        close(authChannel)
+                        return
+                }
 
-		if strings.Contains(r.URL.String(), "/error/") || strings.Contains(r.URL.String(), "/access_token/") {
-			oAuthToken = getImplicitResponseDataFromURL(r.URL.String())
-			activePage = implicitWebpage.GetResponsePage(oAuthToken.Error)
-		}
-	})
+                if strings.Contains(r.URL.String(), "/error/") || strings.Contains(r.URL.String(), "/access_token/") {
+                        oAuthToken = getImplicitResponseDataFromURL(r.URL.String())
+                        activePage = implicitWebpage.GetResponsePage(oAuthToken.Error)
+                }
+        })
 
-	if c.SecureLoginEnabled() {
-		log.SetOutput(ioutil.Discard)
-		log.Fatal(http.ListenAndServeTLS(":" + u.Port(), os.TempDir() + "cert.pem", os.TempDir() + "key.pem", nil))
-	} else {
-		log.Fatal(http.ListenAndServe(":" + u.Port(), nil))
-	}
+        if c.SecureLoginEnabled() {
+                log.SetOutput(ioutil.Discard)
+                log.Fatal(http.ListenAndServeTLS(":"+u.Port(), os.TempDir()+"cert.pem", os.TempDir()+"key.pem", nil))
+        } else {
+                log.Fatal(http.ListenAndServe(":"+u.Port(), nil))
+        }
 }
 
 // parse data from url in the format '/access_token/12345/expires_in/299/token_type/bearer'
 func getImplicitResponseDataFromURL(url string) models.OAuthToken {
-	var response models.OAuthToken
-	splitURL := strings.Split(url, "/")
-	for i, v := range splitURL {
-		if v == "error" {
-			response.Error = splitURL[i+1]
-			break
-		}
-		if v == "access_token" {
-			response.AccessToken = splitURL[i+1]
-		} else if v == "expires_in" {
-			response.ExpiresIn, _ = strconv.Atoi(splitURL[i+1])
-		} else if v == "token_type" {
-			response.TokenType = splitURL[i+1]
-		}
-	}
-	return response
+        var response models.OAuthToken
+        splitURL := strings.Split(url, "/")
+        for i, v := range splitURL {
+                if v == "error" {
+                        response.Error = splitURL[i+1]
+                        break
+                }
+                if v == "access_token" {
+                        response.AccessToken = splitURL[i+1]
+                } else if v == "expires_in" {
+                        response.ExpiresIn, _ = strconv.Atoi(splitURL[i+1])
+                } else if v == "token_type" {
+                        response.TokenType = splitURL[i+1]
+                }
+        }
+        return response
 }
 
 func openBrowserForLoginFunc(loginURL string) {
-	var err error
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", loginURL).Start()
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", loginURL).Start()
-	case "darwin":
-		err = exec.Command("open", loginURL).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-	if err != nil {
-		logger.Fatal(err)
-	}
+        var err error
+        switch runtime.GOOS {
+        case "linux":
+                err = exec.Command("xdg-open", loginURL).Start()
+        case "windows":
+                err = exec.Command("rundll32", "url.dll,FileProtocolHandler", loginURL).Start()
+        case "darwin":
+                err = exec.Command("open", loginURL).Start()
+        default:
+                err = fmt.Errorf("unsupported platform")
+        }
+        if err != nil {
+                logger.Fatal(err)
+        }
 }
 
-//NewRESTClient is a constructor function to build an APIClient
+// NewRESTClient is a constructor function to build an APIClient
 func NewRESTClient(config config.Configuration) *RESTClient {
-	if RestClient == nil && config.AccessToken() == "" {
-		oAuthToken, err := Authorize(config)
-		if err != nil {
-			logger.Fatal(err)
-		}
+        if RestClient == nil && config.AccessToken() == "" {
+                oAuthToken, err := Authorize(config)
+                if err != nil {
+                        logger.Fatal(err)
+                }
 
-		RestClient = &RESTClient{environment: config.Environment(), token: oAuthToken.AccessToken, configuration: config}
-		return RestClient
-	}
+                RestClient = &RESTClient{environment: config.Environment(), token: oAuthToken.AccessToken, configuration: config}
+                return RestClient
+        }
 
-	if RestClient == nil && config.AccessToken() != "" {
-		RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken(), configuration: config}
-	}
+        if RestClient == nil && config.AccessToken() != "" {
+                RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken(), configuration: config}
+        }
 
-	return RestClient
+        return RestClient
 }
 
 func init() {
-	Client = *retryablehttp.NewClient()
-	Client.Logger = nil
-	ClientDo = Client.Do
+        Client = *retryablehttp.NewClient()
+        Client.Logger = nil
+        ClientDo = Client.Do
 }

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -42,6 +42,15 @@ var (
 type RESTClient struct {
 	environment string
 	token       string
+	configuration config.Configuration
+}
+
+func (r *RESTClient) SetEnv(env string) {
+	r.environment = env
+}
+
+func (r *RESTClient) SetConfig(c config.Configuration) {
+	r.configuration = c
 }
 
 //Get executes an HTTP Get
@@ -129,7 +138,34 @@ func (r *RESTClient) callAPI(method string, uri string, data string) (string, er
 			}
 		}
 	}
+    
+    if r.configuration != nil {
+		proxyConfiguration := r.configuration.ProxyConfiguration()
+	if proxyConfiguration != nil && proxyConfiguration.Protocol != "" {
+		var proxyUrl *url.URL
 
+		if proxyConfiguration.Auth != nil && proxyConfiguration.Auth.UserName != "" && proxyConfiguration.Auth.Password != "" {
+			proxyUrl = &url.URL {
+      		Scheme: proxyConfiguration.Protocol,
+     	    User:   url.UserPassword(proxyConfiguration.Auth.UserName, 
+	  							proxyConfiguration.Auth.Password),
+      		Host:   proxyConfiguration.Host + ":" + proxyConfiguration.Port,
+    		}
+		} else {
+				urlString := proxyConfiguration.Protocol + "://" +
+						proxyConfiguration.Host  + ":" +
+						proxyConfiguration.Port
+				proxyUrl, _ = url.Parse(urlString)
+		}
+
+				tr := &http.Transport {
+        			Proxy:  http.ProxyURL(proxyUrl),
+    			}
+
+				Client.HTTPClient.Transport = tr
+	}
+	}
+	
 	//Executing the request
 	resp, err := ClientDo(request)
 	if err != nil {
@@ -381,12 +417,12 @@ func NewRESTClient(config config.Configuration) *RESTClient {
 			logger.Fatal(err)
 		}
 
-		RestClient = &RESTClient{environment: config.Environment(), token: oAuthToken.AccessToken}
+		RestClient = &RESTClient{environment: config.Environment(), token: oAuthToken.AccessToken, configuration: config}
 		return RestClient
 	}
 
 	if RestClient == nil && config.AccessToken() != "" {
-		RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken()}
+		RestClient = &RESTClient{environment: config.Environment(), token: config.AccessToken(), configuration: config}
 	}
 
 	return RestClient


### PR DESCRIPTION
add proxy capabilities for cli

sample toml for reference after the changes

[default]
access_token = ''
client_credentials = '7de3af06-c0b3-4f9b-af45-72f4a14037cc'
client_secret = 'qLh-825gtjPrIY2kcWKAkmlaSgi6Z1Ws2BAyixWbTrs'
environment = 'mypurecloud.com'
oauth_token_data = '{"access_token":"9WGvyFzEnvbf8minYY_gbubnF3ptlTTDA10tK8ARLNa8dKYqln1v3MU5or4Wam8F6UV6rbqQORO2KRvrwCiUhg","token_type":"bearer","expires_in":86399,"error":"","oauth_token_expiry":"2023-04-18T15:00:13+01:00"}'
proxy_host = 'ec2-54-146-246-37.compute-1.amazonaws.com'
proxy_password = 'abc123'
proxy_port = '8888'
proxy_protocol = 'http'
proxy_username = 'john_doe1'
redirect_uri = ''
secure_login_enabled = false