### PR TITLE
jenkins swagger check

### DIFF
--- a/modules/builder.js
+++ b/modules/builder.js
@@ -246,6 +246,14 @@ function prebuildImpl() {
 				);
 			})
 			.then(() => {
+				// For Jenkins only. 
+				if (newSwaggerTempFile.includes('build-platform-sdks-internal-pipeline') && process.argv.includes("is-upstream-cause-and-build-contains-changes")) {
+					if (swaggerDiff.changeCount == 0) {
+						throw new Error('The build was triggered by an upstream cause and contains changes, but the Swagger definition has not been updated.');
+					}
+				}
+			})
+			.then(() => {
 				return addNotifications();
 			})
 			.then(() => {

--- a/modules/builder.js
+++ b/modules/builder.js
@@ -247,9 +247,9 @@ function prebuildImpl() {
 			})
 			.then(() => {
 				// For Jenkins only. 
-				if (newSwaggerTempFile.includes('build-platform-sdks-internal-pipeline') && process.argv.includes("is-upstream-cause-and-build-contains-changes")) {
+				if (newSwaggerTempFile.includes('build-platform-sdks-internal-pipeline') && process.argv.includes("build-contains-upstream-changes")) {
 					if (swaggerDiff.changeCount == 0) {
-						throw new Error('The build was triggered by an upstream cause and contains changes, but the Swagger definition has not been updated.');
+						throw new Error('The build contains upstream changes, but the Swagger definition has not changed.');
 					}
 				}
 			})


### PR DESCRIPTION
This PR is related to https://bitbucket.org/inindca/platform-client-sdk-internal-config/pull-requests/91. Here we check if the build is an internal SDK build and that the command line argument `build-contains-upstream-changes` is present. If those conditions are met, we check if the `swaggerDiff.changeCount == 0` and if it is, throw an error failing the build.