### PR TITLE
Add ctors for NotificationHandler with NotificationsApi parameter

### DIFF
--- a/resources/sdk/pureclouddotnet/extensions/Extensions/Notifications/NotificationHandler.cs
+++ b/resources/sdk/pureclouddotnet/extensions/Extensions/Notifications/NotificationHandler.cs
@@ -59,6 +59,28 @@ namespace {{=it.packageName}}.Extensions.Notifications
         }
 
         /// <summary>
+        /// Creates a new instance of NotificationHandler with custom NotificationsApi
+        /// </summary>
+        public NotificationHandler(NotificationsApi notificationsApi)
+        {
+            _notificationsApi = notificationsApi;
+            Channel = _notificationsApi.PostNotificationsChannels();
+            ConnectSocket(Channel.ConnectUri);
+            SubscribeToSystemEvents();
+        }
+
+        /// <summary>
+        /// Creates a new instance of NotificationHandler with proxy and custom NotificationsApi
+        /// </summary>
+        public NotificationHandler(NotificationsApi notificationsApi, string proxyURI, string proxyUsername = null, string proxyPassword = null)
+        {
+            _notificationsApi = notificationsApi;
+            Channel = _notificationsApi.PostNotificationsChannels();
+            ConnectSocket(Channel.ConnectUri, proxyURI, proxyUsername, proxyPassword);
+            SubscribeToSystemEvents();
+        }
+
+        /// <summary>
         /// Creates a new instance of NotificationHandler from an existing <see cref="Channel"/>
         /// </summary>
         public NotificationHandler(Channel channel)
@@ -73,6 +95,28 @@ namespace {{=it.packageName}}.Extensions.Notifications
         /// </summary>
         public NotificationHandler(Channel channel, string proxyURI, string proxyUsername = null, string proxyPassword = null)
         {
+            Channel = channel;
+            ConnectSocket(Channel.ConnectUri, proxyURI, proxyUsername, proxyPassword);
+            SubscribeToSystemEvents();
+        }
+
+        /// <summary>
+        /// Creates a new instance of NotificationHandler with an existing Channel object and custom NotificationsApi
+        /// </summary>
+        public NotificationHandler(Channel channel, NotificationsApi notificationsApi)
+        {
+            _notificationsApi = notificationsApi;
+            Channel = channel;
+            ConnectSocket(Channel.ConnectUri);
+            SubscribeToSystemEvents();
+        }
+
+        /// <summary>
+        /// Creates a new instance of NotificationHandler with an existing Channel object, proxy, and custom NotificationsApi
+        /// </summary>
+        public NotificationHandler(Channel channel, NotificationsApi notificationsApi, string proxyURI, string proxyUsername = null, string proxyPassword = null)
+        {
+            _notificationsApi = notificationsApi;
             Channel = channel;
             ConnectSocket(Channel.ConnectUri, proxyURI, proxyUsername, proxyPassword);
             SubscribeToSystemEvents();


### PR DESCRIPTION
Hey there! This pull request addresses an important requirement for situations where users need to have more than one NotificationHandler instance running concurrently in their application, such as having a separate thread per organization.  Without these modifications, a default NotificationsApi is created, which internally initializes a static Configurations object in its constructor.

To overcome this limitation, this pull request introduces additional constructors to the NotificationHandler class. These constructors allow users to pass their own NotificationsApi instance, ensuring that each NotificationHandler operates independently with its own dedicated NotificationsApi object. This modification helps prevent potential conflicts and ensures thread-safety when multiple NotificationHandlers are used simultaneously.