### PR TITLE
enable Support content profile feature for web messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains scripts, templates, and configuration files that are us
 * [.NET](https://github.com/MyPureCloud/platform-client-sdk-dotnet)
 * [Python](https://github.com/MyPureCloud/platform-client-sdk-python)
 * [Ruby](https://github.com/MyPureCloud/platform-client-sdk-ruby)
+* [WebMessaging (Java)](https://github.com/MyPureCloud/web-messaging-sdk-java)
 
 **Note:  As of 9.17.2020 - Genesys Cloud has deprecated Ruby SDK support.  The Genesys Cloud team will keep a branch ([FROZEN-LAST-VERSION-RUBY-SDK-GENERATION](https://github.com/purecloudlabs/platform-client-sdk-common/tree/FROZEN-LAST-VERSION-RUBY-SDK-GENERATION)) for the Ruby SDK generation process, but the Ruby SDK code generation will be removed from the main branch in this repository.**
 

--- a/resources/sdk/webmessagingjava/templates/FileUtils.mustache
+++ b/resources/sdk/webmessagingjava/templates/FileUtils.mustache
@@ -1,0 +1,51 @@
+package {{invokerPackage}};
+
+import {{invokerPackage}}.model.FileUploadMode;
+
+import java.util.regex.Pattern;
+
+
+public class FileUtils {
+
+    static final String UNKNOWN_MIME_TYPE = "unknown";
+
+    static final String MIMETYPE_REGEXP = "\\w+\\/[\\w.+]+"; // <letters, digits, '_'>/<letters, digits'_', '.', '+'>
+
+    public static boolean isMimeTypeSupported(String mimeType, FileUploadMode mode) {
+        if(mode == null) {
+            return false;
+        }
+
+        if(UNKNOWN_MIME_TYPE == mimeType) {
+            return mode.getFileTypes().size() > 0;
+        }
+
+        if(!Pattern.matches(MIMETYPE_REGEXP, mimeType)) {
+            return false;
+        }
+
+        return mode.getFileTypes().stream().anyMatch(fileType -> mimeTypeMatches(mimeType, fileType.getType()));
+    }
+
+    public static boolean mimeTypeMatches(String mimeType, String supportedMimeType) {
+        if (supportedMimeType == "*/*") {
+            return Pattern.matches(MIMETYPE_REGEXP, mimeType);
+        }
+
+        String[] mimeTypeSplit = mimeType.split("/");
+        String[] supportedMimeTypeSplit = supportedMimeType.split("/");
+        if(mimeTypeSplit.length != 2 || supportedMimeTypeSplit.length != 2) {
+            return false;
+        }
+        if(!mimeTypeSplit[0].equalsIgnoreCase(supportedMimeTypeSplit[0])) {
+            return false;
+        }
+        if(mimeTypeSplit[1].equalsIgnoreCase(supportedMimeTypeSplit[1])) {
+            return true;
+        }
+        if(supportedMimeTypeSplit[1].startsWith("*")) {
+            return mimeTypeSplit[1].endsWith(supportedMimeType.substring(2));
+        }
+        return false;
+    }
+}

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -634,7 +634,7 @@ public class WebMessagingClient {
                 break;
             case "SessionClearedEvent":
                 for (SessionListener sessionListener : sessionListeners) {
-                    sessionListener.sessionExpiredEvent((SessionClearedEvent) response, rawMessage);
+                    sessionListener.sessionClearedEvent((SessionClearedEvent) response, rawMessage);
                 }
                 break;
             case "JwtResponse":

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -151,7 +151,11 @@ public class WebMessagingClient {
             }
 
             @Override
-                public void sessionClearedEvent(SessionClearedEvent sessionClearedResponse, String rawMessage) {
+            public void sessionClearedEvent(SessionClearedEvent sessionClearedResponse, String rawMessage) {
+            }
+
+            @Override
+            public void getConfigurationResponse(GetConfigurationResponse response, String rawMessage) {
             }
 
             @Override
@@ -337,6 +341,27 @@ public class WebMessagingClient {
             configureAuthenticatedSessionRequest.setToken(token);
             configureAuthenticatedSessionRequest.setData(data);
             String payload = objectMapper.writeValueAsString(configureAuthenticatedSessionRequest);
+
+            webSocket.sendText(payload, true);
+        } catch (JsonProcessingException e) {
+            // no-op
+        }
+    }
+
+    public void getSupportedContentConfiguration(String deploymentId, String token, String origin) {
+        try {
+            this.token = token;
+            this.deploymentId = deploymentId;
+            if (apiClient == null) {
+                initializeApiClient(origin);
+            }
+
+            // Create configuration request
+            GetConfigurationRequest getConfigurationRequest = new GetConfigurationRequest();
+            getConfigurationRequest.setAction(RequestTypeGetConfiguration.GETCONFIGURATION);
+            getConfigurationRequest.setDeploymentId(deploymentId);
+            getConfigurationRequest.setToken(token);
+            String payload = objectMapper.writeValueAsString(getConfigurationRequest);
 
             webSocket.sendText(payload, true);
         } catch (JsonProcessingException e) {
@@ -638,6 +663,11 @@ public class WebMessagingClient {
                     sessionListener.sessionClearedEvent((SessionClearedEvent) response, rawMessage);
                 }
                 break;
+            case "GetConfigurationResponse":
+                for (SessionListener sessionListener : sessionListeners) {
+                    sessionListener.getConfigurationResponse((GetConfigurationResponse) response, rawMessage);
+                }
+                break;
             case "JwtResponse":
                 for (SessionListener sessionListener : sessionListeners) {
                     sessionListener.jwtResponse((JwtResponse) response, rawMessage);
@@ -834,6 +864,15 @@ public class WebMessagingClient {
          * @param rawMessage  The raw message payload JSON as a string
          */
         public void jwtResponse(JwtResponse jwtResponse, String rawMessage);
+
+
+        /**
+        * Raised for responses to url requests (type == BaseResponseType.RESPONSE, class = SessionResponse)
+        *
+        * @param response    The deserialized response
+        * @param rawMessage  The raw message payload JSON as a string
+        */
+        public void getConfigurationResponse(GetConfigurationResponse response, String rawMessage);
 
         /**
          * Raised for unmatched BaseResponseType

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -41,6 +41,27 @@ public class WebMessagingClient {
     private final ArrayList<SessionListener> sessionListeners = new ArrayList<>();
     private ApiClient apiClient;
 
+    private AllowedMedia allowedMediaInbound;
+
+    public AllowedMedia getAllowedMediaInbound() {
+        return allowedMediaInbound;
+    }
+
+    public void setAllowedMediaInbound(AllowedMedia allowedMediaInbound) {
+        this.allowedMediaInbound = allowedMediaInbound;
+    }
+
+    /**
+     * check if a provided mime type is among the allowed one in configuration for inbound content.
+     * @param mimeType
+     * @return true if the mime type is part of the allowed media, false otherwise
+     * @see #getSupportedContentConfiguration(String, String, String)
+     * @see #allowedMediaInbound
+     */
+    public boolean isMimeTypeAllowedInbound(String mimeType) {
+        return FileUtils.isMimeTypeSupported(mimeType, allowedMediaInbound.getInbound());
+    }
+
     /**
     * Inspect a StructuredMessage, looking for Presence events ({@link EventType#PRESENCE} )
     * @param message message to introspect for Presence events
@@ -623,6 +644,8 @@ public class WebMessagingClient {
         Object response = objectMapper.convertValue(baseMessage.getBody(), messageClass);
         switch (className) {
             case "SessionResponse":
+                //set the configured allowed media for Supported Content Profile
+                setAllowedMediaInbound(((SessionResponse)response).getAllowedMedia());
                 // Invoke each listener
                 for (SessionListener sessionListener : sessionListeners) {
                     sessionListener.sessionResponse((SessionResponse) response, rawMessage);
@@ -664,6 +687,7 @@ public class WebMessagingClient {
                 }
                 break;
             case "GetConfigurationResponse":
+                setAllowedMediaInbound(((GetConfigurationResponse)response).getAllowedMedia());
                 for (SessionListener sessionListener : sessionListeners) {
                     sessionListener.getConfigurationResponse((GetConfigurationResponse) response, rawMessage);
                 }

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -418,9 +418,10 @@ public class WebMessagingClient {
     }
 
     /**
-     * send an event by specifying the type
+     * send a Presence event by specifying the subtype
      *
      * @see EventPresence
+     * @see EventPresenceType
      */
     public void sendPresenceEvent(EventPresenceType type) {
         try {

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -151,6 +151,10 @@ public class WebMessagingClient {
             }
 
             @Override
+                public void sessionClearedEvent(SessionClearedEvent sessionClearedResponse, String rawMessage) {
+            }
+
+            @Override
             public void jwtResponse(JwtResponse jwtResponse, String rawMessage) {
                 jwt = jwtResponse.getJwt();
             }
@@ -414,11 +418,11 @@ public class WebMessagingClient {
     }
 
     /**
-     * send an event of type Presence join
+     * send an event by specifying the type
      *
      * @see EventPresence
      */
-    public void sendPresenceEvent() {
+    public void sendPresenceEvent(EventPresenceType type) {
         try {
             SendMessageRequest sendMessageRequest = new SendMessageRequest();
             sendMessageRequest.token(this.token);
@@ -428,7 +432,7 @@ public class WebMessagingClient {
                     .events(Collections.singletonList(new MessageEvent()
                             .eventType(EventType.PRESENCE)
                             .presence(new EventPresence()
-                                    .type(EventPresenceType.JOIN))
+                                    .type(type))
                     ))
             );
             String payload = objectMapper.writeValueAsString(sendMessageRequest);
@@ -436,6 +440,35 @@ public class WebMessagingClient {
         } catch (JsonProcessingException e) {
             // no-op
         }
+    }
+
+    /**
+     * send an event of type Presence join for backward compatibility
+     *
+     * @see EventPresence
+     * @see #sendPresenceEventJoin()
+     */
+    public void sendPresenceEvent() {
+        sendPresenceEventJoin();
+    }
+
+
+    /**
+     * send an event of type Presence join
+     *
+     * @see EventPresence
+     */
+    public void sendPresenceEventJoin() {
+        sendPresenceEvent(EventPresenceType.JOIN);
+    }
+
+    /**
+     * send an event of type Presence clear
+     *
+     * @see EventPresence
+     */
+    public void sendPresenceEventEndUserClear() {
+        sendPresenceEvent(EventPresenceType.JOIN);
     }
 
     /**
@@ -597,6 +630,11 @@ public class WebMessagingClient {
             case "SessionExpiredEvent":
                 for (SessionListener sessionListener : sessionListeners) {
                     sessionListener.sessionExpiredEvent((SessionExpiredEvent) response, rawMessage);
+                }
+                break;
+            case "SessionClearedEvent":
+                for (SessionListener sessionListener : sessionListeners) {
+                    sessionListener.sessionExpiredEvent((SessionClearedEvent) response, rawMessage);
                 }
                 break;
             case "JwtResponse":
@@ -779,6 +817,14 @@ public class WebMessagingClient {
          * @param rawMessage  The raw message payload JSON as a string
          */
         public void sessionExpiredEvent(SessionExpiredEvent sessionExpiredEvent, String rawMessage);
+
+        /**
+         * Raised for responses to url requests (type == BaseResponseType.RESPONSE, class = SessionResponse)
+         *
+         * @param sessionClearedEvent    The deserialized event
+         * @param rawMessage  The raw message payload JSON as a string
+         */
+        public void sessionClearedEvent(SessionClearedEvent sessionClearedEvent, String rawMessage);
 
         /**
          * Raised for responses to url requests (type == BaseResponseType.RESPONSE, class = SessionResponse)


### PR DESCRIPTION
web messaging is now using the "support content profile" to allow or refuse file attachment. 
Adding a new endpoint to query the current configuration (retrieve the allowed media types)