### PR TITLE
Devengage 2019

### DIFF
--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -113,7 +113,7 @@ namespace {{packageName}}.Client
         /// Gets or sets the RestClient.
         /// </summary>
         /// <value>An instance of the RestClient</value>
-        public RestClient RestClient { get; set; }
+        private RestClient RestClient { get; set; }
 
         private RetryConfiguration retryConfig;
         public RetryConfiguration RetryConfig { get; set; }
@@ -223,10 +223,6 @@ namespace {{packageName}}.Client
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
 
-            // set timeout
-           ClientOptions.MaxTimeout = Configuration.Timeout;
-           ClientOptions.UserAgent = Configuration.UserAgent;
-
             // Set SDK version
             request.AddHeader("purecloud-sdk", "{{packageVersion}}");
 
@@ -234,21 +230,30 @@ namespace {{packageName}}.Client
             RestResponse response;
 
 
-            var options = new RestClientOptions(ClientOptions.BaseUrl)
-            {
-                MaxTimeout = ClientOptions.MaxTimeout,
-                UserAgent = ClientOptions.UserAgent
-            };
+            var options = new RestClientOptions(ClientOptions.BaseUrl){};
             
             if (ClientOptions.HttpMessageHandler != null)
             {
                 options = new RestClientOptions(ClientOptions.BaseUrl)
                 {
-                    MaxTimeout = ClientOptions.MaxTimeout,
-                    UserAgent = ClientOptions.UserAgent,
                     ConfigureMessageHandler = _ => ClientOptions.HttpMessageHandler 
                 };
                
+            }
+
+            if (Configuration.UserAgent != null)
+            {
+               options.UserAgent = Configuration.UserAgent;   
+            }
+
+            if (Configuration.Timeout > 0)
+            {
+                options.MaxTimeout = Configuration.Timeout;   
+            }
+
+            if (ClientOptions.Proxy != null)
+            {
+                options.Proxy = ClientOptions.Proxy;   
             }
 
             RestClient = new RestClient(options);
@@ -315,21 +320,30 @@ namespace {{packageName}}.Client
              Retry retry = new Retry(this.RetryConfig);
              RestResponse response;
 
-             var options = new RestClientOptions(ClientOptions.BaseUrl)
-            {
-                MaxTimeout = ClientOptions.MaxTimeout,
-                UserAgent = ClientOptions.UserAgent
-            };
+             var options = new RestClientOptions(ClientOptions.BaseUrl){};
             
             if (ClientOptions.HttpMessageHandler != null)
             {
                 options = new RestClientOptions(ClientOptions.BaseUrl)
                 {
-                    MaxTimeout = ClientOptions.MaxTimeout,
-                    UserAgent = ClientOptions.UserAgent,
                     ConfigureMessageHandler = _ => ClientOptions.HttpMessageHandler 
                 };
                
+            }
+
+            if (Configuration.UserAgent != null)
+            {
+               options.UserAgent = Configuration.UserAgent;   
+            }
+
+            if (ClientOptions.Proxy != null)
+            {
+                options.Proxy = ClientOptions.Proxy;   
+            }
+
+            if (Configuration.Timeout > 0)
+            {
+                options.MaxTimeout = Configuration.Timeout;   
             }
 
             RestClient = new RestClient(options);
@@ -736,10 +750,8 @@ namespace {{packageName}}.Client
         public ClientRestOptions ClientOptions { get; set; }
         public class ClientRestOptions
         {
-            private Uri baseUrl;
-            private string userAgent;
+            public Uri BaseUrl { get; set; }
             private System.Net.IWebProxy proxy;
-            private int maxTimeout;
             private HttpMessageHandler httpMessageHandler;
 
             public HttpMessageHandler HttpMessageHandler
@@ -754,30 +766,6 @@ namespace {{packageName}}.Client
                 }
             }
 
-            public Uri BaseUrl
-            {
-                get
-                {
-                    return baseUrl;
-                }
-                set
-                {
-                    this.baseUrl = value;
-                }
-            }
-
-            public string UserAgent
-            {
-                get
-                {
-                    return userAgent;
-                }
-                set
-                {
-                    this.userAgent = value;
-                }
-            }
-
             public System.Net.IWebProxy Proxy
             {
                 get
@@ -787,18 +775,6 @@ namespace {{packageName}}.Client
                 set
                 {
                     this.proxy = value;
-                }
-            }
-
-            public int MaxTimeout
-            {
-                get
-                {
-                    return maxTimeout;
-                }
-                set
-                {
-                    this.maxTimeout = value;
                 }
             }
             

--- a/resources/sdk/pureclouddotnet/templates/Configuration.mustache
+++ b/resources/sdk/pureclouddotnet/templates/Configuration.mustache
@@ -218,17 +218,7 @@ namespace {{packageName}}.Client
         /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
         /// </summary>
         /// <value>Timeout.</value>
-        public int Timeout
-        {
-            get { 
-                return ApiClient.ClientOptions.MaxTimeout;
-            }
-
-            set {
-                if (ApiClient != null)
-                    ApiClient.ClientOptions.MaxTimeout = value;
-            }
-        }
+        public int Timeout { get; set; }
 
         /// <summary>
         /// Gets or sets the default API client for making HTTP calls.

--- a/resources/sdk/pureclouddotnet/templates/api.mustache
+++ b/resources/sdk/pureclouddotnet/templates/api.mustache
@@ -130,7 +130,7 @@ namespace {{packageName}}.Api
         /// <value>The base path</value>
         public String GetBasePath()
         {
-            return this.Configuration.ApiClient.RestClient.Options.BaseUrl.ToString();
+             return this.Configuration.ApiClient.ClientOptions.BaseUrl.ToString();
         }
 
         /// <summary>

--- a/resources/sdk/webmessagingjava/scripts/combine-swagger.js
+++ b/resources/sdk/webmessagingjava/scripts/combine-swagger.js
@@ -88,13 +88,6 @@ function addDefinitions(definitionBody) {
             addDefinitions(internalSwagger.definitions[responseValuesSchemaDefinition])
         }
 
-        if (propertyValues["$ref"]) {
-            responseValuesSchemaDefinition = propertyValues["$ref"].replace("#/definitions/", "")
-            newSwagger["definitions"][responseValuesSchemaDefinition] = internalSwagger.definitions[responseValuesSchemaDefinition]
-            existingDefinitions.push(responseValuesSchemaDefinition)
-            addDefinitions(internalSwagger.definitions[responseValuesSchemaDefinition])
-        }
-
         // Get definitions by ref from nested objects
         for (const propertyValueKeys of Object.keys(propertyValues)) {
             if (!propertyValues[propertyValueKeys]["$ref"])

--- a/resources/sdk/webmessagingjava/scripts/combine-swagger.js
+++ b/resources/sdk/webmessagingjava/scripts/combine-swagger.js
@@ -88,6 +88,13 @@ function addDefinitions(definitionBody) {
             addDefinitions(internalSwagger.definitions[responseValuesSchemaDefinition])
         }
 
+        if (propertyValues["$ref"]) {
+            responseValuesSchemaDefinition = propertyValues["$ref"].replace("#/definitions/", "")
+            newSwagger["definitions"][responseValuesSchemaDefinition] = internalSwagger.definitions[responseValuesSchemaDefinition]
+            existingDefinitions.push(responseValuesSchemaDefinition)
+            addDefinitions(internalSwagger.definitions[responseValuesSchemaDefinition])
+        }
+
         // Get definitions by ref from nested objects
         for (const propertyValueKeys of Object.keys(propertyValues)) {
             if (!propertyValues[propertyValueKeys]["$ref"])


### PR DESCRIPTION
Previously , Client has this capability to modify underlying RestClient Properties that SDK uses for making their Platform API calls. Since the upgrade, RestClient object has become lot more light weight with most of the responsibilities transferred to RestClientOptions. Made modifications to make sure any changes to the Rest Behaviour can be only done via exposed SDK setter/getter methods of Configuration and ClientOptions classes and propagate their properties while making the API calls via RestSharp.