### PR TITLE
Update Configuration imports to ES6

### DIFF
--- a/resources/sdk/purecloudjavascript-guest/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/README.mustache
@@ -186,7 +186,7 @@ client.config.logger.setLogger(); // To apply above changes
 A number of configuration parameters can be applied using a configuration file. There are two sources for this file:
 
 1. The SDK will look for `%USERPROFILE%\.genesyscloudjavascript-guest\config` on Windows if the environment variable USERPROFILE is defined, otherwise uses the path to the profile directory of the current user as home, or `$HOME/.genesyscloudjavascript-guest/config` on Unix.
-2. Provide a valid file path to `client.config.setConfigPath()`
+2. Provide a valid file path to `client.config.setConfigPath("path/to/config")`
 
 The SDK will constantly check to see if the config file has been updated, regardless of whether a config file was present at start-up. To disable this behaviour, set `client.config.live_reload_config` to false.  
 INI and JSON formats are supported. See below for examples of configuration values in both formats:

--- a/resources/sdk/purecloudjavascript-guest/templates/configuration.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/configuration.mustache
@@ -1,4 +1,8 @@
+import ConfigParser from 'configparser';
+import fs from 'fs';
 import Logger from './logger.js';
+import os from 'os';
+import path from 'path';
 
 class Configuration {
 	/**
@@ -23,8 +27,6 @@ class Configuration {
 		if (typeof window !== 'undefined') {
 			this.configPath = '';
 		} else {
-			const os = require('os');
-			const path = require('path');
 			this.configPath = path.join(os.homedir(), '.genesyscloudjavascript-guest', 'config');
 		}
 		this.live_reload_config = true;
@@ -47,7 +49,6 @@ class Configuration {
 
 			if (this.live_reload_config && this.live_reload_config === true) {
 				try {
-					const fs = require('fs');
 					fs.watchFile(this.configPath, { persistent: false }, (eventType, filename) => {
 						this.updateConfigFromFile();
 						if (!this.live_reload_config) {
@@ -76,7 +77,6 @@ class Configuration {
 			// Please don't remove the typeof window === 'undefined' check here!
 			// This safeguards the browser environment from using `fs`, which is only
 			// available in node environment.
-			const ConfigParser = require('configparser');
 
 			try {
 				var configparser = new ConfigParser();
@@ -85,7 +85,6 @@ class Configuration {
 			} catch (error) {
 				if (error.name && error.name === 'MissingSectionHeaderError') {
 					// Not INI format, see if it's JSON format
-					const fs = require('fs');
 					var configData = fs.readFileSync(this.configPath, 'utf8');
 					this.config = {
 						_sections: JSON.parse(configData), // To match INI data format

--- a/resources/sdk/purecloudjavascript-guest/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript-guest/templates/index.d.ts.mustache
@@ -45,6 +45,7 @@ declare class Configuration {
 	logger: Logger;
 	config: any;
 	setEnvironment(environment: string): void;
+	setConfigPath(path: string): void;
 }
 
 declare class Logger {

--- a/resources/sdk/purecloudjavascript/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript/templates/README.mustache
@@ -296,7 +296,7 @@ client.config.logger.setLogger(); // To apply above changes
 A number of configuration parameters can be applied using a configuration file. There are two sources for this file:
 
 1. The SDK will look for `%USERPROFILE%\.genesyscloudjavascript\config` on Windows if the environment variable USERPROFILE is defined, otherwise uses the path to the profile directory of the current user as home, or `$HOME/.genesyscloudjavascript/config` on Unix.
-2. Provide a valid file path to `client.config.setConfigPath()`
+2. Provide a valid file path to `client.config.setConfigPath("path/to/config")`
 
 The SDK will constantly check to see if the config file has been updated, regardless of whether a config file was present at start-up. To disable this behaviour, set `client.config.live_reload_config` to false.  
 INI and JSON formats are supported. See below for examples of configuration values in both formats:

--- a/resources/sdk/purecloudjavascript/templates/configuration.mustache
+++ b/resources/sdk/purecloudjavascript/templates/configuration.mustache
@@ -1,4 +1,8 @@
+import ConfigParser from 'configparser';
+import fs from 'fs';
 import Logger from './logger.js';
+import os from 'os';
+import path from 'path';
 
 class Configuration {
 	/**
@@ -23,8 +27,6 @@ class Configuration {
 		if (typeof window !== 'undefined') {
 			this.configPath = '';
 		} else {
-			const os = require('os');
-			const path = require('path');
 			this.configPath = path.join(os.homedir(), '.genesyscloudjavascript', 'config');
 		}
 		this.refresh_access_token = true;
@@ -49,7 +51,6 @@ class Configuration {
 
 			if (this.live_reload_config && this.live_reload_config === true) {
 				try {
-					const fs = require('fs');
 					fs.watchFile(this.configPath, { persistent: false }, (eventType, filename) => {
 						this.updateConfigFromFile();
 						if (!this.live_reload_config) {
@@ -78,7 +79,6 @@ class Configuration {
 			// Please don't remove the typeof window === 'undefined' check here!
 			// This safeguards the browser environment from using `fs`, which is only
 			// available in node environment.
-			const ConfigParser = require('configparser');
 
 			try {
 				var configparser = new ConfigParser();
@@ -87,7 +87,6 @@ class Configuration {
 			} catch (error) {
 				if (error.name && error.name === 'MissingSectionHeaderError') {
 					// Not INI format, see if it's JSON format
-					const fs = require('fs');
 					var configData = fs.readFileSync(this.configPath, 'utf8');
 					this.config = {
 						_sections: JSON.parse(configData), // To match INI data format

--- a/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
@@ -63,6 +63,7 @@ declare class Configuration {
 	logger: Logger;
 	config: any;
 	setEnvironment(environment: string): void;
+	setConfigPath(path: string): void;
 }
 
 declare class Logger {


### PR DESCRIPTION
Reported in https://developer.genesys.cloud/forum/t/cant-use-purecloud-platform-client-v2-with-node-js-typescript/12151/10

> ReferenceError: You are trying to import a file after the Jest environment has been torn down

This warning reveals itself when live reloading is enabled and the context of the runtime is Node.js (not a browser). Recommended resolutions did not appear to have an effect on resolving the warning. The warning leads to having an impact on the success of Jest executions in CI/CD tooling.

In this commit:
- Update configuration.js to use ES6 imports. Removes runtime ESM require() from functions. Including the TS config for allowSyntheticDefaultImports in a consuming application does not appear to resolve the warning.
- Update Add TS definition for Configuration.setConfigPath. This definition was missing, keeping TS projects from being able to define a config path. However, the inline require() usage is ultimately the root of the issue.