### PR TITLE
Add logging to CallApiAsync in .NET SDK

### DIFF
--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -357,9 +357,20 @@ namespace {{packageName}}.Client
             }
 
             RestClient = new RestClient(options);
+
+            var fullUrl = RestClient.BuildUri(request);
+            string url = fullUrl == null ? path : fullUrl.ToString();
             do
             {
                 response = await RestClient.ExecuteAsync(request);
+                Configuration.Logger.Debug(method.ToString(), url, postBody, (int)response.StatusCode, headerParams);
+                Configuration.Logger.Trace(method.ToString(), url, postBody, (int)response.StatusCode, headerParams, response.Headers?
+                                                             .Select(header => new
+                                                         {
+                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
+                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                        ?? new Dictionary<string, string>());
             }while(retry.ShouldRetry(response));
 
             if (UsingCodeAuth && Configuration.ShouldRefreshAccessToken)


### PR DESCRIPTION
It is currently available in CallApi (sync) but not in CallApiAsync