### PR TITLE
[DEVTOOLING-767] Net SDK Fix for duplicate header names in HTTP Responses

### DIFF
--- a/resources/sdk/pureclouddotnet/extensions/Extensions/AuthExtensions.cs
+++ b/resources/sdk/pureclouddotnet/extensions/Extensions/AuthExtensions.cs
@@ -103,8 +103,9 @@ namespace {{=it.packageName}}.Extensions
 
             return new ApiResponse<AuthTokenInfo>(statusCode,
                 response.Headers
-                 .Select(header => new { Name = header.GetType().GetProperty("Name").GetValue(header), Value = header.GetType().GetProperty("Value").GetValue(header) })
-                                    .ToDictionary(header => header.Name.ToString(), header => header.Value.ToString()),
+                 .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
+                 .Select(header => new { Name = header.First().GetType().GetProperty("Name").GetValue(header.First()), Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList() })
+                                    .ToDictionary(header => header.Name.ToString(), header => String.Join(", ", header?.Value?.ToArray())),
                 authTokenInfo,
                 response.Content,
                 response.StatusDescription);
@@ -184,8 +185,10 @@ namespace {{=it.packageName}}.Extensions
             apiClient.Configuration.AuthTokenInfo = authTokenInfo;
 
             return new ApiResponse<AuthTokenInfo>(statusCode,
-                response.Headers.Select(header => new { Name = header.GetType().GetProperty("Name").GetValue(header), Value = header.GetType().GetProperty("Value").GetValue(header) })
-                                    .ToDictionary(header => header.Name.ToString(), header => header.Value.ToString()),
+                response.Headers
+                 .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
+                 .Select(header => new { Name = header.First().GetType().GetProperty("Name").GetValue(header.First()), Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList() })
+                                    .ToDictionary(header => header.Name.ToString(), header => String.Join(", ", header?.Value?.ToArray())),
                 authTokenInfo,
                 response.Content,
                 response.StatusDescription);
@@ -307,8 +310,10 @@ namespace {{=it.packageName}}.Extensions
             apiClient.Configuration.AuthTokenInfo = authTokenInfo;
 
             return new ApiResponse<AuthTokenInfo>(statusCode,
-                response.Headers.Select(header => new { Name = header.GetType().GetProperty("Name").GetValue(header), Value = header.GetType().GetProperty("Value").GetValue(header) })
-                                    .ToDictionary(header => header.Name.ToString(), header => header.Value.ToString()),
+                response.Headers
+                 .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
+                 .Select(header => new { Name = header.First().GetType().GetProperty("Name").GetValue(header.First()), Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList() })
+                                    .ToDictionary(header => header.Name.ToString(), header => String.Join(", ", header?.Value?.ToArray())),
                 authTokenInfo,
                 response.Content,
                 response.StatusDescription);
@@ -345,22 +350,24 @@ namespace {{=it.packageName}}.Extensions
             var fullUrl = restClient.BuildUri(request);
             string url = fullUrl == null ? path : fullUrl.ToString();
             apiClient.Configuration.Logger.Trace(method.ToString(), url, postBody, statusCode, headerParams, response.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>());
             apiClient.Configuration.Logger.Debug(method.ToString(), url, postBody, statusCode, headerParams);
 
             if (statusCode >= 400 || statusCode == 0)
                 
                 apiClient.Configuration.Logger.Error(method.ToString(), url, postBody, response.Content, statusCode, headerParams, response.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>());
             return (Object) response;
         }

--- a/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
+++ b/resources/sdk/pureclouddotnet/templates/ApiClient.mustache
@@ -271,11 +271,12 @@ namespace {{packageName}}.Client
             {{/supportsUWP}}
                 Configuration.Logger.Debug(method.ToString(), url, postBody, (int)response.StatusCode, headerParams);
                 Configuration.Logger.Trace(method.ToString(), url, postBody, (int)response.StatusCode, headerParams, response.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>());
 
             }while(retry.ShouldRetry(response));
@@ -293,11 +294,12 @@ namespace {{packageName}}.Client
 
             if ((int)response.StatusCode < 200 || (int)response.StatusCode >= 300)
                 Configuration.Logger.Error(method.ToString(), url, postBody, response.Content, (int)response.StatusCode, headerParams, response.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>());
 
 
@@ -365,11 +367,12 @@ namespace {{packageName}}.Client
                 response = await RestClient.ExecuteAsync(request);
                 Configuration.Logger.Debug(method.ToString(), url, postBody, (int)response.StatusCode, headerParams);
                 Configuration.Logger.Trace(method.ToString(), url, postBody, (int)response.StatusCode, headerParams, response.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>());
             }while(retry.ShouldRetry(response));
 

--- a/resources/sdk/pureclouddotnet/templates/README.mustache
+++ b/resources/sdk/pureclouddotnet/templates/README.mustache
@@ -217,6 +217,13 @@ Set the `RetryMax` to the retries to attempt before returning an error.
 When the retry time is a positive integer, the SDK will follow the recommended backoff logic using the provided configuration.
 The best practices are documented in the [Rate Limiting](https://developer.genesys.cloud/platform/api/rate-limits) Developer Center article.
 
+#### Management of HTTP Responses with duplicate header names.
+
+When an HTTP Response is received with duplicate header names, the SDK will automatically merge such headers and present them as single entry with a comma separated string value.
+This applies to response headers in the ApiResponse class, or when enabling SDK logging.
+
+e.g. HTTP Response with ("Server": "Google") and ("Server": "FrontEnd") will be made available and logged as: "Server": "Google, FrontEnd"
+
 #### SDK Logging
 
 Logging of API requests and responses can be controlled by several parameters on the `Configuration`'s `Logger` instance.

--- a/resources/sdk/pureclouddotnet/templates/api.mustache
+++ b/resources/sdk/pureclouddotnet/templates/api.mustache
@@ -288,11 +288,12 @@ namespace {{packageName}}.Api
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
             Dictionary<string, string> localVarHeaders = localVarResponse.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>();
 
             if (localVarStatusCode >= 400)
@@ -426,11 +427,12 @@ namespace {{packageName}}.Api
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
             Dictionary<string, string> localVarHeaders = localVarResponse.Headers?
+                                                             .GroupBy(header => header.GetType().GetProperty("Name")?.GetValue(header))
                                                              .Select(header => new
                                                          {
-                                                            Name = header.GetType().GetProperty("Name")?.GetValue(header),
-                                                            Value = header.GetType().GetProperty("Value")?.GetValue(header)
-                                                            }).ToDictionary(header => header?.Name?.ToString(), header => header?.Value?.ToString()) 
+                                                            Name = header.First().GetType().GetProperty("Name")?.GetValue(header.First()),
+                                                            Value = header.Select(x => x.GetType().GetProperty("Value")?.GetValue(x)).ToList()
+                                                            }).ToDictionary(header => header?.Name?.ToString(), header => String.Join(", ", header?.Value?.ToArray())) 
                                                         ?? new Dictionary<string, string>();
 
             if (localVarStatusCode >= 400)


### PR DESCRIPTION
Fix for .Net SDK for HTTP Responses with duplicate header names.