### PR TITLE
Ability to set API Host and Login Host (Platform API Javascript SDK)

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -205,6 +205,15 @@ class ApiClient {
 	}
 
 	/**
+	 * @description Sets the api host and the login host used by the session (Genesys Cloud or Gateway)
+	 * @param {string} apiHost - (Optional, default "https://api.mypurecloud.com") The API host the session use (Genesys Cloud or Gateway), e.g. https://api.mypurecloud.ie, https://api.mypurecloud.com.au, etc.
+	 * @param {string} loginHost - (Optional, default "https://login.mypurecloud.com") The Login host the session use (Genesys Cloud or Gateway), e.g. https://login.mypurecloud.ie, https://login.mypurecloud.com.au, etc.
+	 */
+	setCustomEnvironment(apiHost, loginHost) {
+		this.config.setCustomEnvironment(apiHost, loginHost);
+	}
+
+	/**
 	 * @description Initiates the implicit grant login flow. Will attempt to load the token from local storage, if enabled.
 	 * @param {string} clientId - The client ID of an OAuth Implicit Grant client
 	 * @param {string} redirectUri - The redirect URI of the OAuth Implicit Grant client
@@ -280,7 +289,7 @@ class ApiClient {
 			}
 			axios({
 				method: `POST`,
-				url: `https://login.${this.config.environment}/oauth/token`,
+				url: `${this.config.authUrl}/oauth/token`,
 				headers: headers,
 				data: 'grant_type=client_credentials',
 				httpsAgent: this.proxyAgent
@@ -291,7 +300,7 @@ class ApiClient {
 						'trace',
 						response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						headers,
 						response.headers,
 						{ grant_type: 'client_credentials' },
@@ -301,7 +310,7 @@ class ApiClient {
 						'debug',
 						response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						headers,
 						undefined,
 						{ grant_type: 'client_credentials' },
@@ -325,7 +334,7 @@ class ApiClient {
 							'error',
 							error.response.status,
 							'POST',
-							`https://login.${this.config.environment}/oauth/token`,
+							`${this.config.authUrl}/oauth/token`,
 							headers,
 							error.response.headers,
 							{ grant_type: 'client_credentials' },
@@ -371,7 +380,7 @@ class ApiClient {
 						'trace',
 						response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						request.headers,
 						response.headers,
 						bodyParam,
@@ -381,7 +390,7 @@ class ApiClient {
 						'debug',
 						response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						request.headers,
 						undefined,
 						bodyParam,
@@ -405,7 +414,7 @@ class ApiClient {
 							'error',
 							error.response.status,
 							'POST',
-							`https://login.${this.config.environment}/oauth/token`,
+							`${this.config.authUrl}/oauth/token`,
 							request.headers,
 							error.response.headers,
 							bodyParam,
@@ -429,7 +438,7 @@ class ApiClient {
 		return new Promise((resolve, reject) => {
 			var request = axios({
 				method: `POST`,
-				url: `https://login.${this.config.environment}/oauth/token`,
+				url: `${this.config.authUrl}/oauth/token`,
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded'
 				},
@@ -456,7 +465,7 @@ class ApiClient {
 					'trace',
 					response.status,
 					'POST',
-					`https://login.${this.config.environment}/oauth/token`,
+					`${this.config.authUrl}/oauth/token`,
 					request.headers,
 					response.headers,
 					bodyParam,
@@ -466,7 +475,7 @@ class ApiClient {
 					'debug',
 					response.status,
 					'POST',
-					`https://login.${this.config.environment}/oauth/token`,
+					`${this.config.authUrl}/oauth/token`,
 					request.headers,
 					undefined,
 					bodyParam,
@@ -490,7 +499,7 @@ class ApiClient {
 						'error',
 						error.response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						request.headers,
 						error.response.headers,
 						bodyParam,
@@ -821,7 +830,7 @@ class ApiClient {
 					'trace',
 					response.status,
 					'POST',
-					`https://login.${this.config.environment}/oauth/token`,
+					`${this.config.authUrl}/oauth/token`,
 					request.headers,
 					response.headers,
 					bodyParam,
@@ -831,7 +840,7 @@ class ApiClient {
 					'debug',
 					response.status,
 					'POST',
-					`https://login.${this.config.environment}/oauth/token`,
+					`${this.config.authUrl}/oauth/token`,
 					request.headers,
 					undefined,
 					bodyParam,
@@ -857,7 +866,7 @@ class ApiClient {
 						'error',
 						error.response.status,
 						'POST',
-						`https://login.${this.config.environment}/oauth/token`,
+						`${this.config.authUrl}/oauth/token`,
 						request.headers,
 						error.response.headers,
 						bodyParam,
@@ -877,7 +886,7 @@ class ApiClient {
 	_formAuthRequest(encodedData, data) {
 		var request = axios({
 			method: `POST`,
-			url: `https://login.${this.config.environment}/oauth/token`,
+			url: `${this.config.authUrl}/oauth/token`,
 			headers: {
 				'Authorization': 'Basic ' + encodedData,
 				'Content-Type': 'application/x-www-form-urlencoded'

--- a/resources/sdk/purecloudjavascript/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript/templates/README.mustache
@@ -346,6 +346,32 @@ JSON:
 }
 ```
 
+It is also possible to specifically define the urls of the API Host and of the Login Host (Genesys Cloud or your intermediate gateway) using the "host" and "login_host" configuration parameters.
+
+INI:
+
+```ini
+...
+[general]
+live_reload_config = true
+host = https://URL_OR_YOUR_GATEWAY_FOR_API_REQUESTS
+login_host = https://URL_OR_YOUR_GATEWAY_FOR_LOGIN_REQUESTS
+```
+
+JSON:
+
+```json
+{
+    ...
+    "general": {
+        "live_reload_config": true,
+        "host": "https://api.mypurecloud.com"
+        "login_host": "https://login.mypurecloud.com"
+    }
+}
+```
+
+
 ## Environments
 
 If connecting to a Genesys Cloud environment other than mypurecloud.com (e.g. mypurecloud.ie), set the environment on the `ApiClient` instance with the PureCloudRegionHosts object.
@@ -355,6 +381,13 @@ const client = {{moduleName}}.ApiClient.instance;
 client.setEnvironment({{moduleName}}.PureCloudRegionHosts.eu_west_1);
 ```
 
+It is also possible to specifically define the urls of the API Host and of the Login Host (Genesys Cloud or your intermediate gateway) using *setCustomEnvironment(apiHost, LoginHost)* method.
+
+```javascript
+const client = {{moduleName}}.ApiClient.instance;
+client.setCustomEnvironment('https://api.mypurecloud.com', 'https://login.mypurecloud.com');
+client.setCustomEnvironment('https://URL_OR_YOUR_GATEWAY_FOR_API_REQUESTS', 'https://URL_OR_YOUR_GATEWAY_FOR_LOGIN_REQUESTS');
+```
 
 ## Access Token persistence
 

--- a/resources/sdk/purecloudjavascript/templates/configuration.mustache
+++ b/resources/sdk/purecloudjavascript/templates/configuration.mustache
@@ -31,6 +31,7 @@ class Configuration {
 		this.refresh_token_wait_max = 10;
 		this.live_reload_config = true;
 		this.host;
+		this.login_host;
 		this.environment;
 		this.basePath;
 		this.authUrl;
@@ -131,8 +132,10 @@ class Configuration {
 				? this.getConfigBoolean('general', 'live_reload_config')
 				: this.live_reload_config;
 		this.host = this.getConfigString('general', 'host') !== undefined ? this.getConfigString('general', 'host') : this.host;
+		this.login_host = this.getConfigString('general', 'login_host') !== undefined ? this.getConfigString('general', 'login_host') : this.login_host;
 
-		this.setEnvironment();
+		if (!this.login_host) this.setEnvironment();
+		else this.setCustomEnvironment()
 
 		// Update logging configs
 		this.logger.setLogger();
@@ -153,6 +156,22 @@ class Configuration {
 
 		this.basePath = `https://api.${this.environment}`;
 		this.authUrl = `https://login.${this.environment}`;
+	}
+
+	setCustomEnvironment(apiHost, loginHost) {
+		if (apiHost) this.basePath = apiHost;
+		else {
+			this.basePath = this.host ? this.host : 'https://api.mypurecloud.com';
+		}
+		// Strip trailing slash
+		this.basePath = this.basePath.replace(/\/+$/, '');
+
+		if (loginHost) this.authUrl = loginHost;
+		else {
+			this.authUrl = this.login_host ? this.login_host : 'https://login.mypurecloud.com';
+		}
+		// Strip trailing slash
+		this.authUrl = this.authUrl.replace(/\/+$/, '');
 	}
 
 	getConfigString(section, key) {

--- a/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
@@ -21,6 +21,7 @@ declare class ApiClientClass {
 	logout(logoutRedirectUri: string): void;
 	setAccessToken(token: string): void;
 	setEnvironment(environment: string): void;
+	setCustomEnvironment(apiHost: string, loginHost: string): void;
 	setPersistSettings(doPersist: boolean, prefix?: string): void;
 	setReturnExtendedResponses(returnExtended: boolean): void;
 	setStorageKey(storageKey: string): void;
@@ -57,12 +58,14 @@ declare class Configuration {
 	refresh_token_wait_max: number;
 	live_reload_config: boolean;
 	host: string;
+	login_host: string;
 	environment: string;
 	basePath: string;
 	authUrl: string;
 	logger: Logger;
 	config: any;
 	setEnvironment(environment: string): void;
+	setCustomEnvironment(apiHost: string, loginHost: string): void;
 }
 
 declare class Logger {


### PR DESCRIPTION
Platform API Javascript SDK:
Ability to set the API Host and the Login Host (Genesys Cloud regional hosts or custom gateways).

Introducing setCustomEnvironment method (Configuration and ApiClient classes) and login_host config file parameter.