### PR TITLE
Go SDK Build Fix - Uuid as string

### DIFF
--- a/resources/sdk/purecloudgo/config.json
+++ b/resources/sdk/purecloudgo/config.json
@@ -22,7 +22,7 @@
       "codegenLanguage": "purecloudgo",
       "jarPath": "${WORKSPACE}/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar",
       "configFile": "${SDK_TEMP}/config.json",
-      "extraGeneratorOptions": []
+      "extraGeneratorOptions": [ "--type-mappings=UUID=string" ]
     },
     "releaseNoteTemplatePath": "${COMMON_ROOT}/resources/templates/githubSdkReleaseNotes.md",
     "releaseNoteSummaryTemplatePath": "${COMMON_ROOT}/resources/templates/githubSdkReleaseNoteSummary.md",


### PR DESCRIPTION
Go SDK Build Fix - Uuid as string

Fix is done using openapi-generator-cli command options.