### PR TITLE
Add API class constructor to TypeScript definitions

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
@@ -93,7 +93,8 @@ declare class Logger {
 }
 {{#apiInfo}}
 {{#apis}}{{#operations}}
-declare class {{classname}} { {{#operation}} {{!-- class: CodegenOperation --}}
+declare class {{classname}} {
+	constructor(apiClient?: ApiClientClass);{{#operation}}{{!-- class: CodegenOperation --}}
   	{{operationId}}({{#allParams}}{{#required}}{{{paramName}}}: {{{typeScriptType}}}{{#vendorExtensions.x-codegen-hasMoreRequired}}, {{/vendorExtensions.x-codegen-hasMoreRequired}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{{#vendorExtensions.x-codegen-hasRequiredParams}}, {{/vendorExtensions.x-codegen-hasRequiredParams}}opts?: {{classname}}.{{operationId}}Options{{/hasOptionalParams}}): Promise<{{{typeScriptResponseType}}}>;{{/operation}}
 }
 


### PR DESCRIPTION
The API class constructors optionally take an ApiClient instance. This PR adds a construtor to the TypeScript definitions to reflect this.