### PR TITLE
[NO-JIRA] Temporary rollback on Java Object Mapper

### DIFF
--- a/resources/sdk/purecloudjava-guest/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava-guest/templates/ApiClient.mustache
@@ -126,7 +126,6 @@ public class ApiClient implements AutoCloseable {
     public static ObjectMapper buildObjectMapper(DateFormat dateFormat) {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);

--- a/resources/sdk/purecloudjava-guest/templates/Logger.mustache
+++ b/resources/sdk/purecloudjava-guest/templates/Logger.mustache
@@ -360,7 +360,6 @@ class Logger {
                 ObjectMapper objectMapper = new ObjectMapper();
                 objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
                 objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-                objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
                 try {
                     return objectMapper.writeValueAsString(this);
                 } catch (Exception e) {

--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -164,7 +164,6 @@ public class ApiClient implements AutoCloseable {
     public static ObjectMapper buildObjectMapper(DateFormat dateFormat) {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/resources/sdk/purecloudjava/templates/Logger.mustache
+++ b/resources/sdk/purecloudjava/templates/Logger.mustache
@@ -361,7 +361,6 @@ class Logger {
                 ObjectMapper objectMapper = new ObjectMapper();
                 objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
                 objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-                objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
                 try {
                     return objectMapper.writeValueAsString(this);
                 } catch (Exception e) {

--- a/resources/sdk/webmessagingjava/templates/ApiClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/ApiClient.mustache
@@ -102,7 +102,6 @@ public class ApiClient implements AutoCloseable {
     public static ObjectMapper buildObjectMapper(DateFormat dateFormat) {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);


### PR DESCRIPTION
Temporary rollback on Java Object Mapper settings (meant for empty arrays), as it has a side effect on a couple of API endpoints (on empty string and empty object). Change will be evaluated again to take into account this.