### PR TITLE
[DEVTOOLING-1006] Javascript Warning in Vite for https library

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -1,5 +1,4 @@
 import Configuration from './configuration.js';
-import https from 'https';
 import DefaultHttpClient from './DefaultHttpClient.js';
 import AbstractHttpClient from './AbstractHttpClient.js';
 import HttpRequestOptions from './HttpRequestOptions.js';
@@ -256,11 +255,11 @@ class ApiClient {
 
 			agentOptions.rejectUnauthorized = true
 
-			this.proxyAgent = new https.Agent(agentOptions);
+			this.proxyAgent = new require('https').Agent(agentOptions);
 			const httpClient = this.getHttpClient();
 			httpClient.setHttpsAgent(this.proxyAgent);
 	    } else {
-	         throw new Error("Custom Agent Paths/ File System Access are not supported on Browser. Use setMTLSContents instead");
+	         throw new Error("MTLS authentication is managed by the Browser itself. MTLS certificates cannot be set via code on Browser.");
 	    }
     }
 
@@ -271,24 +270,28 @@ class ApiClient {
      * @param {string} caContent - content for public certs
      */
     setMTLSContents(certContent, keyContent, caContent) {
-		const agentOptions = {}
-		if (certContent) {
-			agentOptions.cert = certContent;
-		}
+		if (typeof window === 'undefined') {
+	    	const agentOptions = {}
+			if (certContent) {
+				agentOptions.cert = certContent;
+			}
 
-		if (keyContent) {
-			agentOptions.key = keyContent;
-		}
+			if (keyContent) {
+				agentOptions.key = keyContent;
+			}
 
-		if (caContent) {
-			agentOptions.ca = caContent;
-		}
+			if (caContent) {
+				agentOptions.ca = caContent;
+			}
 
-		agentOptions.rejectUnauthorized = true
+			agentOptions.rejectUnauthorized = true
 
-		this.proxyAgent = new https.Agent(agentOptions);
-		const httpClient = this.getHttpClient();
-		httpClient.setHttpsAgent(this.proxyAgent);
+			this.proxyAgent = new require('https').Agent(agentOptions);
+			const httpClient = this.getHttpClient();
+			httpClient.setHttpsAgent(this.proxyAgent);
+	    } else {
+	         throw new Error("MTLS authentication is managed by the Browser itself. MTLS certificates cannot be set via code on Browser.");
+	    }
     }
 
 	/**

--- a/resources/sdk/purecloudjavascript/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript/templates/README.mustache
@@ -562,7 +562,7 @@ client.setProxyAgent(agent)
 
 ### Using MTLS authentication via a Gateway
 
-If there is MTLS authentication that need to be set for a gateway server (i.e. if the Genesys Cloud requests must be sent through an intermediate API gateway or equivalent, with MTLS enabled), you can use setMTLSCertificates to set the httpsAgent.
+With Node.js applications, if there is MTLS authentication that need to be set for a gateway server (i.e. if the Genesys Cloud requests must be sent through an intermediate API gateway or equivalent, with MTLS enabled), you can use setMTLSCertificates to set the httpsAgent.
 
 An example using `setMTLSCertificates` to setup MTLS for gateway is shown below
 
@@ -579,6 +579,8 @@ If you want a custom proxy agent with MTLS , you can still use setProxyAgent met
 The responsibility of setting the agent options inside the custom proxy agent will be with the caller.
 
 Use Either setMTLSCertificates, or setProxyAgent or setHttpClient based on your use case, as the properties will be overridden based on what is invoked last.
+
+Note that with javascript's Browser applications, MTLS is to be managed and supported by the Browser itself (Chrome, Firefox, ...), using standard Certificates stores.
 
 ### Inject custom Http Client
 

--- a/resources/sdk/purecloudjavascript/templates/index.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.mustache
@@ -58,8 +58,10 @@ import ApiClient from './ApiClient.js';
 		 * @property {module:<#invokerPackage><invokerPackage>/</invokerPackage>MyPureCloudRegionHost}
 		 */</emitJSDoc>
 		this.PureCloudRegionHosts = PureCloudRegionHosts;
-		
-		
+
+		this.AbstractHttpClient = AbstractHttpClient;
+		this.DefaultHttpClient = DefaultHttpClient;
+		this.HttpRequestOptions = HttpRequestOptions;
 	}
 }<={{ }}=>
 

--- a/resources/sdk/purecloudjavascript/templates/index.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.mustache
@@ -1,5 +1,8 @@
 
 import PureCloudRegionHosts from './PureCloudRegionHosts.js';
+import DefaultHttpClient from './DefaultHttpClient.js';
+import AbstractHttpClient from './AbstractHttpClient.js';
+import HttpRequestOptions from './HttpRequestOptions.js';
 import ApiClient from './ApiClient.js';
 {{#apiInfo}}{{#apis}}import {{importPath}} from './{{#apiPackage}}{{apiPackage}}/{{/apiPackage}}{{importPath}}.js';
 {{/apis}}{{/apiInfo}}


### PR DESCRIPTION
https module is only supported with nodejs.
Import at the beginning of the file is replaced with require('https') in the code. setting of MTLS certificates is only supported with nodejs application - browser client is to manage and to support MTLS aspect in case of webapps.