### PR TITLE
[NO-JIRA] Java SDK - Force API endpoints, per Tag (SCIM), to use csv collectionFormat

### DIFF
--- a/resources/sdk/purecloudjava/config.json
+++ b/resources/sdk/purecloudjava/config.json
@@ -14,7 +14,8 @@
       "oldSwaggerPath": "${SDK_REPO}/swagger.json",
       "newSwaggerPath": "https://api.mypurecloud.com/api/v2/docs/swagger",
       "previewSwaggerPath": "https://api.mypurecloud.com/api/v2/docs/swaggerpreview",
-      "saveNewSwaggerPath": "${SDK_REPO}/swagger.json"
+      "saveNewSwaggerPath": "${SDK_REPO}/swagger.json",
+      "forceCSVCollectionFormatOnTags": [ "SCIM" ]
     },
     "swaggerCodegen": {
       "resourceLanguage": "purecloudjava",


### PR DESCRIPTION
Java SDK - Force API endpoints, per Tag (SCIM), to use csv collectionFormat instead of multi
Query Parameters of type array will be sent via single attribute with comma separated values