### PR TITLE
[NO-JIRA] .NetSDK - Create distinct Configuration/Configuration.ApiClient instances

### DIFF
--- a/resources/sdk/pureclouddotnet/templates/Configuration.mustache
+++ b/resources/sdk/pureclouddotnet/templates/Configuration.mustache
@@ -40,6 +40,7 @@ namespace {{packageName}}.Client
         /// <param name="userAgent">HTTP user agent</param>
         /// <param name="configFilePath">Config file path</param>
         /// <param name="autoReloadConfig">AutoReloadConfig</param>
+        /// <param name="useDefaultApiClient">Use Default ApiClient</param>
         public Configuration(ApiClient apiClient = null,
                              Dictionary<String, String> defaultHeader = null,
                              string username = null,
@@ -54,10 +55,18 @@ namespace {{packageName}}.Client
                              int refreshTokenWaitTime = 10,
                              string userAgent = "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen{{/httpUserAgent}}/dotnet",
                              string configFilePath = null,
-                             bool autoReloadConfig = true
+                             bool autoReloadConfig = true,
+                             bool useDefaultApiClient = true
                             )
         {
-            setApiClientUsingDefault(apiClient);
+            if (useDefaultApiClient == true)
+            {
+                setApiClientUsingDefault(apiClient);
+            }
+            else
+            {
+                setApiClient(apiClient);
+            }
 
             Username = username;
             Password = password;
@@ -111,6 +120,39 @@ namespace {{packageName}}.Client
         public Configuration(ApiClient apiClient)
         {
             setApiClientUsingDefault(apiClient);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Configuration class.
+        /// </summary>
+        /// <param name="apiClient">Api client.</param>
+        /// <param name="setDefaultApiClient">Set Default ApiClient</param>
+        public Configuration(ApiClient apiClient,
+                             bool setDefaultApiClient
+                            )
+        {
+            if (setDefaultApiClient == true)
+            {
+                setApiClientUsingDefault(apiClient);
+            }
+            else
+            {
+                setApiClient(apiClient);
+            }
+
+            Timeout = 100000;
+            ShouldRefreshAccessToken = true;
+            RefreshTokenWaitTime = 10;
+
+            Logger = new Logger();
+            
+            string homePath = (Environment.OSVersion.Platform == PlatformID.Unix ||
+                                Environment.OSVersion.Platform == PlatformID.MacOSX)
+                    ? Environment.GetEnvironmentVariable("HOME")
+                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
+            ConfigFilePath = Path.Combine(homePath, ".genesysclouddotnet", "config");
+            
+            AutoReloadConfig = false;
         }
 
         private void applyConfigFromFile()
@@ -284,6 +326,25 @@ namespace {{packageName}}.Client
                     Default.ApiClient = apiClient;
 
                 ApiClient = apiClient;
+            }
+        }
+
+        /// <summary>
+        /// Set or create the ApiClient.
+        /// </summary>
+        /// <param name="apiClient">An instance of ApiClient.</param>
+        /// <returns></returns>
+        public void setApiClient (ApiClient apiClient = null)
+        {
+            AuthTokenInfo = new AuthTokenInfo();
+            if (apiClient == null)
+            {
+                ApiClient = new ApiClient(this);
+            }
+            else
+            {
+                ApiClient = apiClient;
+                ApiClient.Configuration = this;
             }
         }
 

--- a/resources/sdk/pureclouddotnet/templates/README.mustache
+++ b/resources/sdk/pureclouddotnet/templates/README.mustache
@@ -446,6 +446,25 @@ var me = usersApi.GetMe();
 Console.WriteLine($"Hello, {me.DisplayName}");
 ```
 
+#### Using multiple ApiClients
+
+Applications which need to create and to maintain distinct Configuration and ApiClient instances (i.e. distinct instances to different Genesys Cloud regions or to the same region, with distinct access tokens), can use the optional `useDefaultApiClient` parameter (set to: false - default: true), of the `Configuration` constructor.
+
+When the `useDefaultApiClient` optional parameter is not specified or is set to true (`useDefaultApiClient` default value is true), the SDK sets or uses the ApiClient of the Default Configuration (static single instance).
+
+**To create and to use distinct Configuration.ApiClient instances, set the `useDefaultApiClient` optional parameter to false.**
+
+```csharp
+        Configuration configuration = new Configuration(useDefaultApiClient: false);
+        ApiClient client =  configuration.ApiClient;
+        PureCloudRegionHosts region = PureCloudRegionHosts.eu_west_1;
+        client.setBasePath(region);
+
+        var apiInstance = new UsersApi(configuration);
+        var userId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";  // string | User ID
+        User resultUser = apiInstance.GetUser(userId, null, null, null);
+```
+
 ## NotificationHandler Helper Class
 
 The .NET SDK includes a helper class `NotificationHandler` to assist in managing GenesysCloud notifications. The class will create a single notification channel, or use an existing one, and provides methods to add and remove subscriptions and raises an event with a deserialized notification object whenever one is received.


### PR DESCRIPTION
Configuration constructor currently leverages the ApiClient of the Default Configuration instance (static). The change is to facilitate the creation of Configuration and ApiClient instances that dot not rely on the Default Configuration singleton - allowing to maintain distinct ApiClients to different regions (or same region with different access tokens).