### PR TITLE
[NO-JIRA] JS SDK - fixing typo in typescript definition

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
@@ -122,7 +122,7 @@ declare class DefaultHttpClient {
 	setTimeout(timeout: number): void;
 	setHttpsAgent(httpsAgent: any): void;
 	request(httpRequestOptions: HttpRequestOptions): Promise<any>;
-    toAxiosConfig(httpRequestOptions: RequestOptions): any;
+    toAxiosConfig(httpRequestOptions: HttpRequestOptions): any;
 }
 
 declare class Logger {


### PR DESCRIPTION
JS SDK - fixing typo in typescript definition