### PR TITLE
SHYRKA-2902 Update WebMessaging SDK

### DIFF
--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -73,6 +73,10 @@ public class WebMessagingClient {
         return webSocket;
     }
 
+	  /**
+		* get the default app name, mainly read from property file
+		*
+		*/
 		public static String getDefaultAppName() {
 			return DEFAULT_APP_NAME;
 		}

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -23,6 +24,7 @@ import java.util.Collections;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -32,6 +34,10 @@ import java.util.Map;
  * A client used to connect to a Web Messaging session
  */
 public class WebMessagingClient {
+
+		private static String DEFAULT_APP_NAME;
+
+
     private final String webSocketAddress;
     private WebSocket webSocket;
     private String token;
@@ -42,6 +48,34 @@ public class WebMessagingClient {
     private ApiClient apiClient;
 
     private AllowedMedia allowedMediaInbound;
+
+		static {
+			Properties props = new Properties();
+			String SDK_VERSION;
+			try (InputStream is = WebMessagingClient.class.getResourceAsStream("/props.properties")) {
+				props.load(is);
+				SDK_VERSION = props.getProperty("props.version");
+				DEFAULT_APP_NAME = props.getProperty("props.name") + "-" + SDK_VERSION;
+			} catch (IOException | NullPointerException e) {
+			// Fallback version if properties file cannot be read
+			DEFAULT_APP_NAME = "WebMessagingSDK-1.0.0";
+			}
+		}
+
+		/**
+     * Returns the current WebSocket connection instance.
+     *
+     * @return the WebSocket instance representing the active connection,
+     *         or null if no connection has been established
+     * @see WebSocket
+     */
+    public WebSocket getWebSocket() {
+        return webSocket;
+    }
+
+		public static String getDefaultAppName() {
+			return DEFAULT_APP_NAME;
+		}
 
     public AllowedMedia getAllowedMediaInbound() {
         return allowedMediaInbound;
@@ -264,7 +298,7 @@ public class WebMessagingClient {
         if (connectionTimeout.isPresent()) {
             builder.connectTimeout(Duration.ofSeconds(connectionTimeout.get()));
         }
-        String urlEncodedAppName = URLEncoder.encode(applicationName.orElse("WebMessagingSDK-{{version}}"), StandardCharsets.UTF_8);
+				String urlEncodedAppName = URLEncoder.encode(applicationName.orElse(DEFAULT_APP_NAME), StandardCharsets.UTF_8);
 
         CompletableFuture<WebSocket> completableFuture = builder.buildAsync(URI.create(webSocketAddress + "?deploymentId=" + deploymentId +
                 "&application="+urlEncodedAppName), listener);
@@ -298,7 +332,7 @@ public class WebMessagingClient {
      * @param origin       Represents the origin of the request. You can restrict access in Messenger Deployments
      */
     public void configureSession(String deploymentId, String origin) {
-        configureSession(deploymentId, UUID.randomUUID().toString(), origin, Optional.empty());
+        configureSession(deploymentId, UUID.randomUUID().toString(), origin, UUID.randomUUID().toString(), Optional.empty());
     }
 
     /**
@@ -310,7 +344,7 @@ public class WebMessagingClient {
     * @param startNew     true if you want to start a new session for your currently read-only session (after a Presence event of type {@link EventPresenceType#DISCONNECT})
     *
     */
-    public void configureSession(String deploymentId, String token, String origin, Optional<Boolean> startNew) {
+    public void configureSession(String deploymentId, String token, String origin, String tracingId, Optional<Boolean> startNew) {
         try {
             this.token = token;
             this.deploymentId = deploymentId;
@@ -323,6 +357,7 @@ public class WebMessagingClient {
             configureSessionRequest.setAction(RequestTypeConfigureSession.CONFIGURESESSION);
             configureSessionRequest.setDeploymentId(deploymentId);
             configureSessionRequest.setToken(token);
+						configureSessionRequest.setTracingId(tracingId);
             startNew.ifPresent(boolValue -> configureSessionRequest.setStartNew(boolValue));
             String payload = objectMapper.writeValueAsString(configureSessionRequest);
 
@@ -340,7 +375,8 @@ public class WebMessagingClient {
      * @param data         The session OAuthParams for configuring Authenticated Session
      */
     public void configureAuthenticatedSession(String deploymentId, String origin, OAuthParams data) {
-        configureAuthenticatedSession(deploymentId, UUID.randomUUID().toString(), origin, data);
+        configureAuthenticatedSession(deploymentId, UUID.randomUUID().toString(), origin, data,
+                UUID.randomUUID().toString(), Optional.empty());
     }
 
     /**
@@ -351,7 +387,8 @@ public class WebMessagingClient {
      * @param origin       Represents the origin of the request. You can restrict access in Messenger Deployments
      * @param data         The session OAuthParams for configuring Authenticated Session
      */
-    public void configureAuthenticatedSession(String deploymentId, String token, String origin, OAuthParams data) {
+    public void configureAuthenticatedSession(String deploymentId, String token, String origin, OAuthParams data,
+                                              String tracingId, Optional<Boolean> startNew) {
         try {
             this.token = token;
             this.deploymentId = deploymentId;
@@ -364,6 +401,8 @@ public class WebMessagingClient {
             configureAuthenticatedSessionRequest.setAction(RequestTypeConfigureAuthenticatedSession.CONFIGUREAUTHENTICATEDSESSION);
             configureAuthenticatedSessionRequest.setDeploymentId(deploymentId);
             configureAuthenticatedSessionRequest.setToken(token);
+					  configureAuthenticatedSessionRequest.setTracingId(tracingId);
+            startNew.ifPresent(boolValue -> configureAuthenticatedSessionRequest.setStartNew(boolValue));
             configureAuthenticatedSessionRequest.setData(data);
             String payload = objectMapper.writeValueAsString(configureAuthenticatedSessionRequest);
 
@@ -374,6 +413,10 @@ public class WebMessagingClient {
     }
 
     public void getSupportedContentConfiguration(String deploymentId, String token, String origin) {
+        getSupportedContentConfiguration(deploymentId, token, origin, UUID.randomUUID().toString());
+    }
+
+    public void getSupportedContentConfiguration(String deploymentId, String token, String origin, String tracingId) {
         try {
             this.token = token;
             this.deploymentId = deploymentId;
@@ -386,6 +429,7 @@ public class WebMessagingClient {
             getConfigurationRequest.setAction(RequestTypeGetConfiguration.GETCONFIGURATION);
             getConfigurationRequest.setDeploymentId(deploymentId);
             getConfigurationRequest.setToken(token);
+						getConfigurationRequest.setTracingId(tracingId);
             String payload = objectMapper.writeValueAsString(getConfigurationRequest);
 
             webSocket.sendText(payload, true);
@@ -401,15 +445,20 @@ public class WebMessagingClient {
         webSocket.sendClose(1000, "Guest client disconnect");
     }
 
+		public void ping() {
+        ping(UUID.randomUUID().toString());
+    }
+
     /**
      * Sends a message that will cause a response to ensure the connection is active
      */
-    public void ping() {
+    public void ping(String tracingId) {
         try {
             // Create echo notification
             SendEchoRequest sendEchoRequest = new SendEchoRequest();
             sendEchoRequest.token(this.token);
             sendEchoRequest.setAction(RequestTypeEchoMessage.ECHO);
+						sendEchoRequest.tracingId(tracingId);
             IncomingNormalizedMessage incomingNormalizedMessage = new IncomingNormalizedMessage();
             incomingNormalizedMessage.setType(NormalizedType.TEXT);
             incomingNormalizedMessage.setText("ping");
@@ -429,7 +478,7 @@ public class WebMessagingClient {
      * @param attachmentIds The Id of the attachments being sent with the message
      */
     public void sendMessage(String message, String... attachmentIds) {
-        sendMessage(message, null, attachmentIds);
+        sendMessage(message, null, UUID.randomUUID().toString(), attachmentIds);
     }
 
     /**
@@ -439,11 +488,12 @@ public class WebMessagingClient {
      * @param customAttributes Key Value Pair that allows custom data to be sent with a message
      * @param attachmentIds    The Id of the attachments being sent with the message
      */
-    public void sendMessage(String message, Map<String, String> customAttributes, String... attachmentIds) {
+    public void sendMessage(String message, Map<String, String> customAttributes, String tracingId, String... attachmentIds) {
         try {
             SendMessageRequest sendMessageRequest = new SendMessageRequest();
             sendMessageRequest.token(this.token);
             sendMessageRequest.action(RequestTypeIncomingMessage.ONMESSAGE);
+						sendMessageRequest.tracingId(tracingId);
             IncomingNormalizedMessage normalizedMessage = new IncomingNormalizedMessage();
             sendMessageRequest.message(normalizedMessage
                     .type(NormalizedType.TEXT)
@@ -473,7 +523,17 @@ public class WebMessagingClient {
      * @see EventPresence
      * @see EventPresenceType
      */
-    public void sendPresenceEvent(EventPresenceType type) {
+    public void sendPresenceEvent(EventPresenceType type ) {
+        sendPresenceEvent(type, UUID.randomUUID().toString());
+    }
+
+    /**
+     * send a Presence event by specifying the subtype
+     *
+     * @see EventPresence
+     * @see EventPresenceType
+     */
+    public void sendPresenceEvent(EventPresenceType type, String tracingId) {
         try {
             SendMessageRequest sendMessageRequest = new SendMessageRequest();
             sendMessageRequest.token(this.token);
@@ -485,7 +545,8 @@ public class WebMessagingClient {
                             .presence(new EventPresence()
                                     .type(type))
                     ))
-            );
+            )
+					  .tracingId(tracingId);
             String payload = objectMapper.writeValueAsString(sendMessageRequest);
             webSocket.sendText(payload, true);
         } catch (JsonProcessingException e) {
@@ -522,16 +583,21 @@ public class WebMessagingClient {
         sendPresenceEvent(EventPresenceType.CLEAR);
     }
 
+    public void sendTypingEvent() {
+        sendTypingEvent(UUID.randomUUID().toString());
+    }
+
     /**
      * send an event of type Typing on
      *
      * @see EventTyping
      */
-    public void sendTypingEvent() {
+    public void sendTypingEvent(String tracingId) {
         try {
             SendMessageRequest sendMessageRequest = new SendMessageRequest();
             sendMessageRequest.token(this.token);
             sendMessageRequest.action(RequestTypeIncomingMessage.ONMESSAGE);
+					  sendMessageRequest.tracingId(tracingId);
             sendMessageRequest.message(new IncomingNormalizedMessage()
                     .type(NormalizedType.EVENT)
                     .events(Collections.singletonList(new MessageEvent()
@@ -550,13 +616,21 @@ public class WebMessagingClient {
      * send a request to generate an upload url for an attachment
      */
     public void attachment(String fileName, int fileSize, String fileType) {
+        attachment(fileName, fileSize, fileType, UUID.randomUUID().toString());
+    }
+
+    /**
+     * send a request to generate an upload url for an attachment and trace the request using the provided tracingId
+     */
+    public void attachment(String fileName, int fileSize, String fileType, String tracingId) {
         try {
             GenerateUploadUrlRequest generateUploadUrlRequest = new GenerateUploadUrlRequest()
                     .token(this.token)
                     .action(RequestTypeGenerateUploadUrl.ONATTACHMENT)
                     .fileName(fileName)
                     .fileSize(fileSize)
-                    .fileType(fileType);
+                    .fileType(fileType)
+										.tracingId(tracingId);
 
             String payload = objectMapper.writeValueAsString(generateUploadUrlRequest);
             webSocket.sendText(payload, true);
@@ -569,11 +643,19 @@ public class WebMessagingClient {
      * send a request to generate a download url for an attachment
      */
     public void getAttachment(String attachmentId) {
+        getAttachment(attachmentId, UUID.randomUUID().toString());
+    }
+
+    /**
+     * send a request to generate a download url for an attachment and trace the request using the provided tracingId
+     */
+    public void getAttachment(String attachmentId, String tracingId) {
         try {
             GenerateDownloadUrlRequest generateDownloadUrlRequest = new GenerateDownloadUrlRequest()
               .token(this.token)
               .action(RequestTypeGenerateDownloadUrl.GETATTACHMENT)
-              .attachmentId(attachmentId);
+              .attachmentId(attachmentId)
+							.tracingId(tracingId);
 
             String payload = objectMapper.writeValueAsString(generateDownloadUrlRequest);
             webSocket.sendText(payload, true);
@@ -583,14 +665,22 @@ public class WebMessagingClient {
     }
 
 		/**
+     * delete an attachment. Must not have been sent and trace the request using the provided tracingId
+     */
+    public void deleteAttachment(String attachmentId) {
+        deleteAttachment(attachmentId, UUID.randomUUID().toString());
+    }
+
+		/**
 		* delete an attachment. Must not have been sent
 		*/
-    public void deleteAttachment(String attachmentId) {
+    public void deleteAttachment(String attachmentId, String tracingId) {
         try {
             DeleteAttachmentRequest deleteAttachmentRequest = new DeleteAttachmentRequest()
               .token(this.token)
               .action(RequestTypeDeleteAttachment.DELETEATTACHMENT)
-              .attachmentId(attachmentId);
+              .attachmentId(attachmentId)
+							.tracingId(tracingId);
 
             String payload = objectMapper.writeValueAsString(deleteAttachmentRequest);
             webSocket.sendText(payload, true);
@@ -599,11 +689,15 @@ public class WebMessagingClient {
         }
     }
 
-    public void getJwt() {
+		public void getJwt() {
+        getJwt(UUID.randomUUID().toString());
+    }
+    public void getJwt(String tracingId) {
         try {
             GetJwtRequest getJwtRequest = new GetJwtRequest()
               .token(this.token)
-              .action(RequestTypeGetJwt.GETJWT);
+              .action(RequestTypeGetJwt.GETJWT)
+							.tracingId(tracingId);
 
             String payload = objectMapper.writeValueAsString(getJwtRequest);
             webSocket.sendText(payload, true);

--- a/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
+++ b/resources/sdk/webmessagingjava/templates/WebMessagingClient.mustache
@@ -743,8 +743,14 @@ public class WebMessagingClient {
             return;
         }
 
-        Object response = objectMapper.convertValue(baseMessage.getBody(), messageClass);
-        switch (className) {
+						String tracingId = baseMessage.getTracingId();
+						Object response = objectMapper.convertValue(baseMessage.getBody(), messageClass);
+						try {
+								((BaseResponse)(response)).setTracingId(tracingId);
+						} catch (ClassCastException e) {
+
+						}
+						switch (className) {
             case "SessionResponse":
                 //set the configured allowed media for Supported Content Profile
                 setAllowedMediaInbound(((SessionResponse)response).getAllowedMedia());

--- a/resources/sdk/webmessagingjava/templates/pom.xml.mustache
+++ b/resources/sdk/webmessagingjava/templates/pom.xml.mustache
@@ -63,6 +63,14 @@
   </distributionManagement>
 
   <build>
+		<resources>
+			<resource>
+				<directory>.</directory>
+				<includes>
+					<include>**/*.properties</include>
+				</includes>
+			</resource>
+		</resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description
Update WebMessaging SDK

## Problem
customer reported missing access to recently added field _tracingId_ in requests. Some methods were missing the ability to set this parameter

## Solution
- add the parameter to non generated method
- add getter to the underlying websocket, so that in case of missing feature customers still can craft themselves requests
- Added server-side validation as a safety net

## Bonus
changed the way the application name parameter is generating it's default value. It should include the SDK version number if not set by client
Added also parameter _startNew_ for method _configureAuthenticatedSession_ . This parameter was already available to configureSession for un-authenticated user