### PR TITLE
[DEVTOOLING-1186] CLI SDK - Fix Gateway Configuration with empty login or api path params

### DIFF
--- a/resources/sdk/clisdkclient/extensions/config/config.go
+++ b/resources/sdk/clisdkclient/extensions/config/config.go
@@ -149,7 +149,7 @@ func (c *configuration) Environment() string {
 }
 
 func MapEnvironment(env string) string {
-	if env != "localhost" && !strings.Contains(env, ".") {
+	if env != "localhost" && !strings.Contains(env, ".") && !strings.HasPrefix(env, "localhost:") {
 		basePath, ok := RegionMappings[env]
 		if !ok {
 			fmt.Println("Invalid AWS region:", env)

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -646,10 +646,12 @@ func getConfUrl(c config.Configuration, path string, extendedPath string, overri
         if len(gateWayConfiguration.PathParams) > 0 {
             params := gateWayConfiguration.PathParams
            if tempValue, exists := params[path]; exists {
-                if !strings.HasPrefix(tempValue, "/") {
-                   pathValue = fmt.Sprintf("/%v", tempValue)
-                } else {
-                    pathValue = fmt.Sprintf("%v", tempValue)
+                if tempValue != "" {
+                   if !strings.HasPrefix(tempValue, "/") {
+                      pathValue = fmt.Sprintf("/%v", tempValue)
+                   } else {
+                      pathValue = fmt.Sprintf("%v", tempValue)
+                   }
                 }
            }
          }


### PR DESCRIPTION
Fix CLI Gateway Configuration on empty path params (incorrect uri when the login or api path param is an empty string).
Allow connection to locahost:$port (localhost only allowed at this time).
