### PR TITLE
[DEVTOOLING-1187] Go SDK - Fix Gateway Configuration with empty login or api path params

### DIFF
--- a/resources/sdk/purecloudgo/templates/apiclient.mustache
+++ b/resources/sdk/purecloudgo/templates/apiclient.mustache
@@ -106,10 +106,12 @@ func getConfUrl(c *Configuration, path string, extendedPath string) *url.URL {
 			if param.PathName == path {
 				tempValue := param.PathValue
 
-				if !strings.HasPrefix(tempValue, "/") {
-					pathValue = fmt.Sprintf("/%v", tempValue)
-				} else {
-					pathValue = fmt.Sprintf("%v", tempValue)
+				if tempValue != "" {
+					if !strings.HasPrefix(tempValue, "/") {
+						pathValue = fmt.Sprintf("/%v", tempValue)
+					} else {
+						pathValue = fmt.Sprintf("%v", tempValue)
+					}
 				}
 				break
 			}


### PR DESCRIPTION
Fix Go SDK Gateway Configuration on empty path params (incorrect uri when the login or api path param is an empty string).