### PR TITLE
[NO-JIRA] Java SDK - Force thread count to 1

### DIFF
--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -301,8 +301,16 @@ public class ApiClient implements AutoCloseable {
         hookManager.addPreRequestHook(hook);
     }
 
+    public void removePreRequestHook(PreRequestHook hook) {
+        hookManager.removePreRequestHook(hook);
+    }
+
     public void addPostResponseHook(PostResponseHook hook) {
         hookManager.addPostResponseHook(hook);
+    }
+
+    public void removePostResponseHook(PostResponseHook hook) {
+        hookManager.removePostResponseHook(hook);
     }
 
     /**

--- a/resources/sdk/purecloudjava/templates/testng-integration.mustache
+++ b/resources/sdk/purecloudjava/templates/testng-integration.mustache
@@ -1,5 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="SDK tests" verbose="1" parallel="tests" thread-count="3">
+<suite name="SDK tests" verbose="1" parallel="tests" thread-count="1">
     <listeners>
         <listener class-name="com.mypurecloud.sdk.v2.InvokedMethodListener" />
     </listeners>

--- a/resources/sdk/purecloudjava/tests/SdkTests.java
+++ b/resources/sdk/purecloudjava/tests/SdkTests.java
@@ -276,6 +276,9 @@ public class SdkTests {
 
             User user = usersApi.getUser(userId, Collections.singletonList("profileSkills"), null, null);
 
+            apiClient.removePreRequestHook(preHook);
+            apiClient.removePostResponseHook(postHook);
+
             Assert.assertTrue(prehookExecuted[0], "Prehook was not executed");
             Assert.assertTrue(posthookExecuted[0], "Posthook was not executed");
 


### PR DESCRIPTION
Java SDK - Force thread count to 1 in testing (prod pipeline).
This is to temporarily work around the test issue on Java SDK (Prod) with 3 threads and the pre/post hook test