### PR TITLE
[DEVTOOLING-1415] Override default browser open command on Linux CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jasmine",
     "browserify": "browserify modules/swagger/swaggerDiffImpl.ts -o docs/swaggerDiffImpl.ts",
     "ios": "tsx sdkBuilder.ts --sdk purecloudswift4",
+    "sdk_cli": "tsx sdkBuilder.ts --sdk clisdkclient",
     "sdk_js": "tsx sdkBuilder.ts --sdk purecloudjavascript",
     "sdk_js_chat": "tsx sdkBuilder.ts --sdk purecloudjavascript-guest",
     "sdk_java": "tsx sdkBuilder.ts --sdk purecloudjava",

--- a/resources/sdk/clisdkclient/resources/operationNameOverrides.json
+++ b/resources/sdk/clisdkclient/resources/operationNameOverrides.json
@@ -611,5 +611,10 @@
 		"get": {
 			"name": "listallsources"
 		}
-	}
+	},
+    "/api/v2/carrierservices/report/usage/calls/csv/{conversationId}": {
+        "post": {
+            "name": "createforconv"
+        }
+    }
 }

--- a/resources/sdk/clisdkclient/templates/README.md
+++ b/resources/sdk/clisdkclient/templates/README.md
@@ -329,6 +329,18 @@ Optionally, and for added security, you can choose to open an HTTPS connection f
 
 For more information about the PKCE Grant login process, check out [this article](https://developer.genesys.cloud/api/rest/authorization/use-pkce) on our Developer Center.
 
+# Windows Subsystem for Linux (WSL)
+
+When creating a profile with the `gc profiles new` command, for an Implicit Grant or a PKCE Grant, the user is redirected to their browser where they can authenticate themselves by logging into their Genesys Cloud org.
+
+By default, the linux version of the CLI will use the "xdg-open" command to open the browser.
+
+In order to provide flexibility on WSL, where "xdg-open" may not be installed, you can make use of the GENESYSCLOUD_BROWSER environment variable to change the browser command. Set the GENESYSCLOUD_BROWSER environment variable with the desired command before running the CLI.
+
+e.g. If you want to use explorer.exe and the the location of the explorer.exe is in your $PATH, you can use `export GENESYSCLOUD_BROWSER="explorer.exe"`
+
+e.g. If you want to use Chrome and the location of chrome is NOT in your $PATH, find the path to your chrome application from wsl. The path to your C drive may vary based on your installation (i.e. /mnt/c or /mnt/host/c or ...). Once you have located the chrome.exe, set the full path in the environment variable: `export GENESYSCLOUD_BROWSER="/mnt/host/c/Program Files/Google/Chrome/Application/chrome.exe"`
+
 # Experimental Features
 
 Experimental `CLI` features were released in version 18.0.0 of the `Genesys Cloud CLI`. Experimental features allow us to release ideas around the `CLI` early and give customers an opportunity to give feedback on the features before the work on them is finalized. Experimental features are tied to the `CLI` binary, so when we release an experimental feature or promote an experimental feature, you will need to download the `CLI` binary that matches the release or promotion of that feature.

--- a/resources/sdk/clisdkclient/templates/restclient.mustache
+++ b/resources/sdk/clisdkclient/templates/restclient.mustache
@@ -590,7 +590,12 @@ func openBrowserForLoginFunc(loginURL string) {
         var err error
         switch runtime.GOOS {
         case "linux":
-                err = exec.Command("xdg-open", loginURL).Start()
+                linuxBrowser := os.Getenv("GENESYSCLOUD_BROWSER")
+                if linuxBrowser != "" {
+                        err = exec.Command(linuxBrowser, loginURL).Start()
+                } else {
+                        err = exec.Command("xdg-open", loginURL).Start()
+                }
         case "windows":
                 err = exec.Command("rundll32", "url.dll,FileProtocolHandler", loginURL).Start()
         case "darwin":


### PR DESCRIPTION
Override default browser open command on Linux CLI

Refers to this post: https://community.genesys.com/discussion/support-profiles-in-wsl?ReplyInline=34e68815-be81-4f21-932b-16ca46bc6a35

Alternative approach: add/support a GENESYSCLOUD_BROWSER environment variable to override default browser command on Linux version of the CLI