### PR TITLE
[DEVTOLLINg-1432] Expose getting and setting of default HTTP headers

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -211,6 +211,50 @@ class ApiClient {
 		this.config.setEnvironment(environment);
 	}
 
+	/**
+     * @description Sets the optional http headers used by the client
+     * @param {object} newHeaders - default headers to be used
+     */
+	setDefaultHeaders(newHeaders) {
+        if (!newHeaders || !(typeof newHeaders === 'object')) {
+            throw new Error("default headers must be a map");
+        }
+        this.defaultHeaders = newHeaders;
+    }
+
+	/**
+     * @description Gets the default http headers used by the client
+     */
+	getDefaultHeaders() {
+		return this.defaultHeaders;
+    }
+
+	/**
+     * @description Sets the optional Genesys-App http header used by the client
+     * @param {string} headerValue - value for the Genesys-App header
+     */
+	setGenesysAppHeader(headerValue) {
+		if (!headerValue || !(typeof headerValue === 'string')) throw new Error("headerValue must be a non empty string");
+        if (!this.defaultHeaders) {
+			this.defaultHeaders = {
+				"Genesys-App": headerValue
+			};
+		} else {
+			this.defaultHeaders["Genesys-App"] = headerValue;
+		}
+    }
+
+	/**
+     * @description Gets the Genesys-App http header used by the client
+     */
+	getGenesysAppHeader() {
+		if (this.defaultHeaders && this.defaultHeaders["Genesys-App"]) {
+			return this.defaultHeaders["Genesys-App"];
+		} else {
+			return null;
+		}
+    }
+
     /**
      * @description Sets the dynamic HttpClient used by the client
      * @param {object} httpClient - HttpClient to be injected

--- a/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
+++ b/resources/sdk/purecloudjavascript/templates/index.d.ts.mustache
@@ -23,6 +23,10 @@ declare class ApiClientClass {
 	logout(logoutRedirectUri: string): void;
 	setAccessToken(token: string): void;
 	setEnvironment(environment: string): void;
+	setDefaultHeaders(newHeaders: Record<string, string>): void;
+	getDefaultHeaders(): Record<string, string>;
+	setGenesysAppHeader(headerValue: string): void;
+	getGenesysAppHeader(): string | null;
 	setGateway(gateway: GatewayConfiguration): void;
 	setPersistSettings(doPersist: boolean, prefix?: string): void;
 	setReturnExtendedResponses(returnExtended: boolean): void;


### PR DESCRIPTION
Expose getting and setting of default HTTP headers.
A specific header will be needed in the future for Genesys builtin apps. This PR is to provide/expose this capability in the Javascript SDK (already covered in Java SDK), for Genesys builtin apps that would make use of the Public Platform API SDK.