### PR TITLE
[NO-JIRA] Replace browser method for generation of PKCE Code Challenge

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -729,7 +729,7 @@ class ApiClient {
 			const utf8 = new TextEncoder().encode(code);
 			return new Promise((resolve, reject) => {
 				window.crypto.subtle.digest("SHA-256", utf8).then((hashBuffer) => {
-					const hashBase64 = Buffer.from(hashBuffer).toString('base64');
+					const hashBase64 = btoa(String.fromCharCode(...new Uint8Array(hashBuffer)));
 					let hashBase64Url = hashBase64.replaceAll("+", "-").replaceAll("/", "_");
 					hashBase64Url = hashBase64Url.split("=")[0];
 					resolve(hashBase64Url);


### PR DESCRIPTION
Replace browser method for generation of PKCE Code Challenge in Javacript SDK to avoid use of Buffer and polyfills.
The web-cjs version of the library was making use of polyfills.
But some web framework (vite) and bundler (webpack) are making use of the nodejs version of the library and don't manage polyfills by default anymore. The method for PKCE Code Challenge now uses javascript API instead of Buffer.