### PR TITLE
[DEVTOOLING-1557] DO NOT MERGE - Javascript SDK - Move parameter filter to modern method by default

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjavascript/templates/ApiClient.mustache
@@ -72,7 +72,7 @@ class ApiClient {
 			MULTI: 'multi'
 		};
 
-		this.useLegacyParameterFilter = true;
+		this.useLegacyParameterFilter = false;
 
 		/**
 		 * @description Value is `true` if local storage exists. Otherwise, false.

--- a/resources/sdk/purecloudjavascript/templates/README.mustache
+++ b/resources/sdk/purecloudjavascript/templates/README.mustache
@@ -436,15 +436,17 @@ The SDK is implemented so that when one of its API method is invoked, it filters
 
 A new ApiClient property (accessed using getUseLegacyParameterFilter and setUseLegacyParameterFilter) is introduced to control the method used to filter out such parameters.
 
-When UseLegacyParameterFilter is true, the SDK will use the legacy filter method.
+When UseLegacyParameterFilter is true, the SDK will use the legacy filter method.  
+When UseLegacyParameterFilter is false, the SDK will use the modern and accurate filter method.
 
-*The UseLegacyParameterFilter default value is currently equal to true.* You will need to change the UseLegacyParameterFilter value so that the SDK uses modern filter method.
-This choice of default value has been made to facilitate the transition from legacy to modern and accurate parameter filtering, without running the risk to affect existing applications with a change of behavior.
+*The UseLegacyParameterFilter default value is now equal to false.* If you want to preserve the legacy filter method, you will need to change the UseLegacyParameterFilter value so that the SDK uses the legacy filter method.
 
 ```javascript
 const client = {{moduleName}}.ApiClient.instance;
-// To use modern and accurate parameter filtering, set UseLegacyParameterFilter to false
-client.setUseLegacyParameterFilter(false);
+// By default, the SDK uses the modern and accurate parameter filtering (UseLegacyParameterFilter is set to false by default)
+// client.setUseLegacyParameterFilter(false);
+// To continue using the legacy parameter filtering, set UseLegacyParameterFilter to true
+client.setUseLegacyParameterFilter(true);
 ```
 
 ### Setting an intermediate Gateway


### PR DESCRIPTION
Javascript SDK - Move parameter filter to modern and accurate method by default (UseLegacyParameterFilter - default value set to false)