### PR TITLE
[NO-JIRA] Update rollup configuration for the CommonJS Javascript library

### DIFF
--- a/resources/sdk/purecloudjavascript/templates/package.mustache
+++ b/resources/sdk/purecloudjavascript/templates/package.mustache
@@ -41,6 +41,7 @@
     "expect.js": "~0.3.1",
     "@babel/core": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
+    "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
     "rollup": "^2.79.1",
     "uglify-es": "^3.3.9",
     "browserify": "^17.0.0",

--- a/resources/sdk/purecloudjavascript/templates/rollup-cjs-for-browserify.config.mustache
+++ b/resources/sdk/purecloudjavascript/templates/rollup-cjs-for-browserify.config.mustache
@@ -36,6 +36,19 @@ export default {
 	plugins: [
 		builtins(),
 		nodeResolve({ browser: true }),
+		babel({
+			babelHelpers: 'bundled',
+			// extensions: ['.js'],
+			include: [
+				'src/**',
+				'node_modules/axios/**'
+			],
+			// presets: [
+			// 	['@babel/preset-env', { modules: false }]
+			// ]
+			// or add:
+			plugins: ['@babel/plugin-transform-nullish-coalescing-operator']
+		}),
 		replace({
 			// https://github.com/rollup/rollup-plugin-commonjs/issues/166#issuecomment-328853157
 			// do replace before commonjs


### PR DESCRIPTION
Update rollup configuration for the CommonJS Javascript library
Axios dependency makes use of nullish coalescing operator, that causes rollup to fail when bundling the CommonJS (cjs) library. The rollup configuration for cjs is updated to leverage babel plugin to replace the nullish coalescing operator.