### PR TITLE
DEVTOOLING-1735: bump jackson to 2.21.4 to fix CVE-2026-54512

### DIFF
--- a/resources/sdk/webmessagingjava/templates/pom.xml.mustache
+++ b/resources/sdk/webmessagingjava/templates/pom.xml.mustache
@@ -236,12 +236,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson-version}</version>
+      <version>${jackson-annotations-version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>${jackson-version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -292,7 +292,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <swagger-annotations-version>1.5.8</swagger-annotations-version>
 		<slf4j-version>2.0.17</slf4j-version>
-		<jackson-version>2.18.6</jackson-version>
+		<jackson-version>2.21.4</jackson-version>
+		<jackson-annotations-version>2.21</jackson-annotations-version>
 		<jodatime-version>2.14.1</jodatime-version>
 		<apache-httpclient-version>4.5.14</apache-httpclient-version>
 		<okhttpclient-version>4.12.0</okhttpclient-version>


### PR DESCRIPTION
- jackson-core, jackson-databind, jackson-jaxrs, jackson-datatype-joda: 2.21.4
- jackson-annotations: 2.21 (annotations dropped patch versioning since 2.20)
- jackson-databind now uses ${jackson-version} instead of hardcoded 2.15.2