### PR TITLE
[DEVTOOLING-1740] Python SDK: enable endpoints with agentic path

### DIFF
--- a/modules/builder/builder.ts
+++ b/modules/builder/builder.ts
@@ -962,7 +962,7 @@ function overrideOperations(overrideOperationIds: any) {
 function processPaths() {
 	const paths = Object.keys(swaggerDiff.newSwagger.paths);
 	for (const path of paths) {
-		if (!path.startsWith("/api/v2") || (path.startsWith("/api/v2/apps") && _this.config.settings.swaggerCodegen.codegenLanguage === "purecloudpython")) {
+		if (!path.startsWith("/api/v2") || (path.startsWith("/api/v2/apps") && !path.startsWith("/api/v2/apps/agentic") && _this.config.settings.swaggerCodegen.codegenLanguage === "purecloudpython")) {
 			delete swaggerDiff.newSwagger.paths[path]
 		}
 	}


### PR DESCRIPTION
Python SDK: enable endpoints with path starting with /api/v2/apps/agentic