### PR TITLE
[DEVTOOLING-1744] Net SDK: disable deprecated mozroots and cert-sync execution

### DIFF
--- a/resources/sdk/pureclouddotnet/scripts/compile.sh
+++ b/resources/sdk/pureclouddotnet/scripts/compile.sh
@@ -9,14 +9,15 @@ echo "ROOT_NAMESPACE=$ROOT_NAMESPACE"
 # CD to build dir
 cd $BUILD_DIR
 
+# DISABLE: mozroots is now deprecated. cert-sync should have been already installed during mono installation
 # Import certs
-if test -f "/etc/pki/tls/certs/ca-bundle.crt"; then
-	echo "Using cert-sync"
-	cert-sync /etc/pki/tls/certs/ca-bundle.crt
-else
-	echo "Using mozroots"
-	mozroots --import --sync
-fi
+# if test -f "/etc/pki/tls/certs/ca-bundle.crt"; then
+# 	echo "Using cert-sync"
+# 	cert-sync /etc/pki/tls/certs/ca-bundle.crt
+# else
+# 	echo "Using mozroots"
+# 	mozroots --import --sync
+# fi
 
 # Install packages
 echo "Installing packages"

--- a/resources/sdk/pureclouddotnet/templates/compile-mono.sh.mustache
+++ b/resources/sdk/pureclouddotnet/templates/compile-mono.sh.mustache
@@ -3,7 +3,8 @@ frameworkVersion={{targetFrameworkNuget}}
 netfx=${frameworkVersion#net}
 
 wget -nc "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
-mozroots --import --sync
+# DISABLE: mozroots is now deprecated. cert-sync should have been already installed during mono installation
+# mozroots --import --sync
 mono nuget.exe install src/{{packageName}}/packages.config -o packages -NoHttpCache -Verbosity detailed;
 mkdir -p bin;
 


### PR DESCRIPTION
Remove invocation of mozroots and certsync in the .Net SDK building process.

mozroots is now deprecated. And cert-sync should already be installed and run during mono installation (docker).